### PR TITLE
feat: add copy button to metadata section

### DIFF
--- a/src/components/copy-metadata/index.tsx
+++ b/src/components/copy-metadata/index.tsx
@@ -1,0 +1,46 @@
+import {
+  Box,
+  Button,
+  ButtonProps,
+  Flex,
+  FlexProps,
+  useClipboard,
+} from 'nde-design-system';
+import React from 'react';
+import { FaCopy } from 'react-icons/fa';
+
+/*
+ [COMPONENT INFO]: Button that copies string to clipboard.
+*/
+
+interface CopyMetadataProps extends FlexProps {
+  metadataObject: string;
+  buttonProps?: ButtonProps;
+}
+
+export const CopyMetadata: React.FC<CopyMetadataProps> = ({
+  metadataObject,
+  buttonProps,
+  ...props
+}) => {
+  const { onCopy, hasCopied } = useClipboard(metadataObject);
+
+  return (
+    <Flex alignItems='flex-end' flexDirection='column' {...props}>
+      <Box position='relative' w='100%'>
+        {/* Simple button with */}
+        <Button
+          leftIcon={<FaCopy />}
+          colorScheme='primary'
+          onClick={onCopy}
+          variant='solid'
+          w='100%'
+          px={{ base: 4, md: 6 }}
+          {...buttonProps}
+        >
+          {hasCopied ? 'Metadata copied!' : 'Copy Metadata'}
+        </Button>
+      </Box>
+    </Flex>
+  );
+};

--- a/src/components/resource-sections/index.tsx
+++ b/src/components/resource-sections/index.tsx
@@ -11,6 +11,8 @@ import {
   Tag,
   Text,
   UnorderedList,
+  Wrap,
+  WrapItem,
 } from 'nde-design-system';
 import {
   ResourceDates,
@@ -25,6 +27,7 @@ import FilesTable from './components/files-table';
 import FundingTable from './components/funding-table';
 import CitedByTable from './components/cited-by-table';
 import { DisplayHTMLContent } from '../html-content';
+import { CopyMetadata } from '../copy-metadata';
 import { DownloadMetadata } from '../download-metadata';
 import SoftwareInformation from './components/software-information';
 import ResourceStats from './components/stats';
@@ -249,15 +252,23 @@ const Sections = ({
             {/* Show raw metadata */}
             {section.hash === 'metadata' && data?.rawData && (
               <>
-                <Flex w='100%' justifyContent='flex-end' pb={4}>
-                  <DownloadMetadata
-                    buttonProps={{ colorScheme: 'secondary' }}
-                    exportName={data.rawData['_id']}
-                    params={{ q: `_id:"${data.rawData['_id']}"` }}
-                  >
-                    Download Metadata
-                  </DownloadMetadata>
-                </Flex>
+                <Wrap spacing='10px' justify='right' pb={4}>
+                  <WrapItem>
+                    <CopyMetadata
+                      buttonProps={{ colorScheme: 'secondary' }}
+                      metadataObject={JSON.stringify(data.rawData, null, 2)}
+                    />
+                  </WrapItem>
+                  <WrapItem>
+                    <DownloadMetadata
+                      buttonProps={{ colorScheme: 'secondary' }}
+                      exportName={data.rawData['_id']}
+                      params={{ q: `_id:"${data.rawData['_id']}"` }}
+                    >
+                      Download Metadata
+                    </DownloadMetadata>
+                  </WrapItem>
+                </Wrap>
                 <Box
                   maxHeight={500}
                   overflow='auto'


### PR DESCRIPTION
# Summary

This PR  addresses issue #209 and adds a button to the metadata section that allows visitors to copy the metadata to the clipboard. 