### PR TITLE
Access Resource button in the Resource Access and Provenance sections

### DIFF
--- a/src/components/resource-sections/components/provenance/index.tsx
+++ b/src/components/resource-sections/components/provenance/index.tsx
@@ -51,9 +51,16 @@ const Provenance: React.FC<Provenance> = ({
     children: React.ReactNode;
     label?: string;
     url?: string | null;
+    sourceRecordUrl?: string | null;
   }
 
-  const Block = ({ children, label, url, ...props }: BlockProps) => {
+  const Block = ({
+    children,
+    label,
+    url,
+    sourceRecordUrl,
+    ...props
+  }: BlockProps) => {
     return (
       <Flex
         border='1px solid'
@@ -75,7 +82,7 @@ const Provenance: React.FC<Provenance> = ({
           </>
         )}
         <>{children}</>
-        {url ? (
+        {sourceRecordUrl ? (
           <Flex
             mt={2}
             justifyContent='flex-end'
@@ -94,7 +101,7 @@ const Provenance: React.FC<Provenance> = ({
                   },
             }}
           >
-            <NextLink href={url} target='_blank'>
+            <NextLink href={sourceRecordUrl} target='_blank'>
               <Button
                 as='span'
                 variant='outline'
@@ -163,6 +170,7 @@ const Provenance: React.FC<Provenance> = ({
               key={includedInDataCatalog.name}
               label='Provided By'
               url={url}
+              sourceRecordUrl={includedInDataCatalog.dataset}
               mr={3}
               ml={0}
             >

--- a/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
@@ -32,66 +32,77 @@ export const DataAccess: React.FC<DataAccessProps> = ({
 }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
 
-  if (!isLoading && !includedInDataCatalog) {
-    return <></>;
+  if (!isLoading) {
+    if (!includedInDataCatalog) return null;
+    if (recordType === 'ResourceCatalog' && url) {
+      return (
+        <Flex mt={4} flexDirection='column' alignItems='flex-start'>
+          <NextLink href={url} target='_blank'>
+            <Button
+              colorScheme={colorScheme}
+              size='sm'
+              rightIcon={<FaArrowRight />}
+            >
+              Access Resource
+            </Button>
+          </NextLink>
+        </Flex>
+      );
+    }
   }
 
   const sources =
-    !isLoading && includedInDataCatalog && recordType !== 'ResourceCatalog'
+    !isLoading && includedInDataCatalog
       ? getSourceDetails(includedInDataCatalog)
       : [];
 
   return (
     <Stack mt={4} flexDirection='column' alignItems='flex-start' spacing={4}>
-      {sources.map(source => {
-        return (
-          <React.Fragment key={source.name}>
-            <SourceLogo
-              sources={[source]}
-              url={source.url}
-              imageProps={{
-                width: 'auto',
-                height: 'unset',
-                maxHeight: '80px',
-                mb: 1,
+      {sources.map(source => (
+        <React.Fragment key={source.name}>
+          <SourceLogo
+            sources={[source]}
+            url={source.url}
+            imageProps={{
+              width: 'auto',
+              height: 'unset',
+              maxHeight: '80px',
+              mb: 1,
+            }}
+          />
+          {source.dataset && (
+            <Flex
+              w='100%'
+              mt={2}
+              justifyContent='flex-end'
+              sx={{
+                svg: {
+                  transform: 'translateX(-2px)',
+                  transition: 'transform 0.2s ease-in-out',
+                },
               }}
-            />
-            {source.dataset ? (
-              <Flex
-                w='100%'
-                mt={2}
-                justifyContent='flex-end'
-                sx={{
-                  svg: {
-                    transform: 'translateX(-2px)',
-                    transition: 'transform 0.2s ease-in-out',
-                  },
-                }}
-                _hover={{
-                  svg: prefersReducedMotion
-                    ? {}
-                    : {
-                        transform: 'translateX(4px)',
-                        transition: 'transform 0.2s ease-in-out',
-                      },
-                }}
-              >
-                <NextLink href={source.dataset} target='_blank'>
-                  <Button
-                    colorScheme={colorScheme}
-                    size='sm'
-                    rightIcon={<FaArrowRight />}
-                  >
-                    Access Resource
-                  </Button>
-                </NextLink>
-              </Flex>
-            ) : (
-              <></>
-            )}
-          </React.Fragment>
-        );
-      })}
+              _hover={{
+                svg: prefersReducedMotion
+                  ? {}
+                  : {
+                      transform: 'translateX(4px)',
+                      transition: 'transform 0.2s ease-in-out',
+                    },
+              }}
+            >
+              <NextLink href={source.dataset} target='_blank'>
+                <Button
+                  colorScheme={colorScheme}
+                  size='sm'
+                  rightIcon={<FaArrowRight />}
+                >
+                  Access Resource
+                </Button>
+              </NextLink>
+            </Flex>
+          )}
+        </React.Fragment>
+      ))}
     </Stack>
   );
 };

--- a/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
@@ -27,13 +27,11 @@ const AccessResourceButton: React.FC<{ url: string; colorScheme: string }> = ({
   url,
   colorScheme,
 }) => (
-  <Flex mt={4} flexDirection='column' alignItems='flex-start'>
-    <NextLink href={url} target='_blank'>
-      <Button colorScheme={colorScheme} size='sm' rightIcon={<FaArrowRight />}>
-        Access Resource
-      </Button>
-    </NextLink>
-  </Flex>
+  <NextLink href={url} target='_blank'>
+    <Button colorScheme={colorScheme} size='sm' rightIcon={<FaArrowRight />}>
+      Access Resource
+    </Button>
+  </NextLink>
 );
 
 export const DataAccess: React.FC<DataAccessProps> = ({

--- a/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
@@ -23,6 +23,19 @@ interface DataAccessProps {
   colorScheme?: ButtonProps['colorScheme'];
 }
 
+const AccessResourceButton: React.FC<{ url: string; colorScheme: string }> = ({
+  url,
+  colorScheme,
+}) => (
+  <Flex mt={4} flexDirection='column' alignItems='flex-start'>
+    <NextLink href={url} target='_blank'>
+      <Button colorScheme={colorScheme} size='sm' rightIcon={<FaArrowRight />}>
+        Access Resource
+      </Button>
+    </NextLink>
+  </Flex>
+);
+
 export const DataAccess: React.FC<DataAccessProps> = ({
   isLoading,
   includedInDataCatalog,
@@ -35,19 +48,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
   if (!isLoading) {
     if (!includedInDataCatalog) return null;
     if (recordType === 'ResourceCatalog' && url) {
-      return (
-        <Flex mt={4} flexDirection='column' alignItems='flex-start'>
-          <NextLink href={url} target='_blank'>
-            <Button
-              colorScheme={colorScheme}
-              size='sm'
-              rightIcon={<FaArrowRight />}
-            >
-              Access Resource
-            </Button>
-          </NextLink>
-        </Flex>
-      );
+      return <AccessResourceButton url={url} colorScheme={colorScheme} />;
     }
   }
 
@@ -90,15 +91,10 @@ export const DataAccess: React.FC<DataAccessProps> = ({
                     },
               }}
             >
-              <NextLink href={source.dataset} target='_blank'>
-                <Button
-                  colorScheme={colorScheme}
-                  size='sm'
-                  rightIcon={<FaArrowRight />}
-                >
-                  Access Resource
-                </Button>
-              </NextLink>
+              <AccessResourceButton
+                url={source.dataset}
+                colorScheme={colorScheme}
+              />
             </Flex>
           )}
         </React.Fragment>

--- a/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
@@ -18,6 +18,7 @@ interface DataAccessProps {
   isLoading: boolean;
   includedInDataCatalog?: FormattedResource['includedInDataCatalog'];
   url?: FormattedResource['url'];
+  recordType?: string | null;
   children?: React.ReactNode;
   colorScheme?: ButtonProps['colorScheme'];
 }
@@ -26,6 +27,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
   isLoading,
   includedInDataCatalog,
   url,
+  recordType,
   colorScheme = 'primary',
 }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -35,7 +37,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
   }
 
   const sources =
-    !isLoading && includedInDataCatalog
+    !isLoading && includedInDataCatalog && recordType !== 'ResourceCatalog'
       ? getSourceDetails(includedInDataCatalog)
       : [];
 
@@ -54,7 +56,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
                 mb: 1,
               }}
             />
-            {url ? (
+            {source.dataset ? (
               <Flex
                 w='100%'
                 mt={2}
@@ -74,7 +76,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
                       },
                 }}
               >
-                <NextLink href={url} target='_blank'>
+                <NextLink href={source.dataset} target='_blank'>
                   <Button
                     colorScheme={colorScheme}
                     size='sm'

--- a/src/components/resource-sections/components/sidebar/components/external/index.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/index.tsx
@@ -64,6 +64,7 @@ export const ExternalAccess = ({
           isLoading={isLoading}
           includedInDataCatalog={data?.includedInDataCatalog}
           url={data?.url}
+          recordType={data?.['@type']}
         />
       </Wrapper>
     </>

--- a/src/utils/api/types.ts
+++ b/src/utils/api/types.ts
@@ -185,6 +185,7 @@ export interface IncludedInDataCatalog {
   name: string;
   url?: string | null; //source repo url
   versionDate?: string | null;
+  dataset: string | null;
 }
 
 export interface InfectiousAgent extends PropertyWithPubtator {


### PR DESCRIPTION
# Summary

This PR changes the links associated with the **Access Resource button** in the Resource Access and Provenance sections as follows:

**Resource Access**

- If the record is a `Dataset` or a `ComputationalTool`, the link is derived from `includedInDataCatalog.dataset`.
- If the record is a `ResourceCatalog`, the link is the record's URL. Furthermore, no icons are shown.

**Provenance / Provided by**

- Links are the `includedInDataCatalog.dataset` value regardless of record type.

Related issue: https://github.com/NIAID-Data-Ecosystem/nde-portal/issues/279 