### PR TITLE
Remove knowledge center link from resources menu

### DIFF
--- a/src/components/navigation-bar/routes.json
+++ b/src/components/navigation-bar/routes.json
@@ -31,11 +31,6 @@
           "href": "/sources"
         },
         {
-          "label": "Knowledge Center",
-          "subLabel": "Guides and documentation to help navigate and use the Discovery Portal",
-          "href": "/knowledge-center"
-        },
-        {
           "label": "News & Updates",
           "subLabel": "Latest news and updates from the NIAID Data Ecosystem",
           "href": "/news"


### PR DESCRIPTION
# Summary

This PR removes the **Knowledge Center** link from the **Resources** menu.



