### PR TITLE
[User Interface: Redesign]: Make accessibility and cost information less button-lik

### DIFF
--- a/src/components/badges/components/AccessibleForFree.tsx
+++ b/src/components/badges/components/AccessibleForFree.tsx
@@ -1,5 +1,4 @@
 import { FormattedResource } from 'src/utils/api/types';
-import { FaDollarSign } from 'react-icons/fa6';
 import { BadgeWithTooltip, BadgeWithTooltipProps } from 'src/components/badges';
 import SchemaDefinitions from 'configs/schema-definitions.json';
 
@@ -21,7 +20,6 @@ export const AccessibleForFree = ({
         colorScheme={isAccessibleForFree ? 'green' : 'gray'}
         value={isAccessibleForFree ? 'Free Access' : 'Paid  Access'}
         tooltipLabel={property?.description[type]}
-        leftIcon={FaDollarSign}
         {...props}
       />
     );

--- a/src/components/badges/components/AccessibleForFree.tsx
+++ b/src/components/badges/components/AccessibleForFree.tsx
@@ -18,7 +18,7 @@ export const AccessibleForFree = ({
     return (
       <BadgeWithTooltip
         colorScheme={isAccessibleForFree ? 'green' : 'gray'}
-        value={isAccessibleForFree ? 'Free Access' : 'Paid  Access'}
+        value={isAccessibleForFree ? 'No Cost Access' : 'Paid  Access'}
         tooltipLabel={property?.description[type]}
         {...props}
       />

--- a/src/components/badges/components/ConditionsOfAccess.tsx
+++ b/src/components/badges/components/ConditionsOfAccess.tsx
@@ -1,5 +1,4 @@
 import { FormattedResource } from 'src/utils/api/types';
-import { FaLock, FaUnlock } from 'react-icons/fa6';
 import { BadgeWithTooltip, BadgeWithTooltipProps } from 'src/components/badges';
 import SchemaDefinitions from 'configs/schema-definitions.json';
 import { transformConditionsOfAccessLabel } from 'src/utils/formatting/formatConditionsOfAccess';
@@ -44,31 +43,11 @@ export const ConditionsOfAccess = ({
     }
   };
 
-  const getIcon = (
-    conditionsOfAccess: ConditionsOfAccessProps['conditionsOfAccess'],
-  ) => {
-    if (conditionsOfAccess?.includes('Open')) {
-      return FaUnlock;
-    } else if (
-      conditionsOfAccess?.includes('Embargoed') ||
-      conditionsOfAccess?.includes('Registered') ||
-      conditionsOfAccess?.includes('Restricted') ||
-      conditionsOfAccess?.includes('Controlled')
-    ) {
-      return FaLock;
-    } else if (
-      conditionsOfAccess?.includes('Varied') ||
-      conditionsOfAccess?.includes('Unknown')
-    ) {
-      return FaUnlock;
-    }
-  };
   return (
     <BadgeWithTooltip
       colorScheme={getColorScheme(conditionsOfAccess)}
       value={transformConditionsOfAccessLabel(conditionsOfAccess)}
       tooltipLabel={property?.description[type]}
-      leftIcon={getIcon(conditionsOfAccess)}
       {...props}
     />
   );

--- a/src/components/badges/components/HasAPI.tsx
+++ b/src/components/badges/components/HasAPI.tsx
@@ -1,8 +1,6 @@
 import { FormattedResource } from 'src/utils/api/types';
-import { Icon } from '@chakra-ui/react';
 import { BadgeWithTooltip, BadgeWithTooltipProps } from 'src/components/badges';
 import SchemaDefinitions from 'configs/schema-definitions.json';
-import { FaCircleCheck, FaCircleXmark } from 'react-icons/fa6';
 import { SchemaDefinitions as SchemaDefinitionsType } from 'scripts/generate-schema-definitions/types';
 
 interface HasDownloadProps extends Omit<BadgeWithTooltipProps, 'value'> {
@@ -22,7 +20,6 @@ export const HasAPI = ({ hasAPI, type, ...props }: HasDownloadProps) => {
     <BadgeWithTooltip
       colorScheme={hasAPI ? 'green' : 'gray'}
       tooltipLabel={type ? property?.description?.[type] || '' : ''}
-      leftIcon={hasAPI ? FaCircleCheck : FaCircleXmark}
       {...props}
     >
       {hasAPI ? 'API Available' : 'API Not Available'}

--- a/src/components/badges/components/HasDownload.tsx
+++ b/src/components/badges/components/HasDownload.tsx
@@ -1,8 +1,6 @@
 import { FormattedResource } from 'src/utils/api/types';
-import { Icon } from '@chakra-ui/react';
 import { BadgeWithTooltip, BadgeWithTooltipProps } from 'src/components/badges';
 import SchemaDefinitions from 'configs/schema-definitions.json';
-import { FaDownload } from 'react-icons/fa6';
 import { SchemaDefinition } from 'scripts/generate-schema-definitions/types';
 
 interface HasDownloadProps extends Omit<BadgeWithTooltipProps, 'value'> {
@@ -43,7 +41,6 @@ export const HasDownload = ({
       tooltipLabel={type ? property?.description?.[type] || '' : ''}
       {...props}
     >
-      <Icon as={FaDownload} mr={1} />
       Has Download: {hasDownload}
     </BadgeWithTooltip>
   );


### PR DESCRIPTION
Addresses issue #290 
1. Removes icons from the following property badges:
- `isAccessibleForFree`
- `conditionsOfAccess`
- `hasAPI`
- `hasDownload`

2. Changes copy on isAccessibleForFree badges from "Free Access" to "No Cost Access"