### PR TITLE
Refactor searchable items

### DIFF
--- a/src/components/resource-sections/index.tsx
+++ b/src/components/resource-sections/index.tsx
@@ -249,7 +249,6 @@ const Sections = ({
                           }}
                         >
                           <SearchableItems
-                            fieldName='about'
                             generateButtonLabel={(
                               limit,
                               length,
@@ -262,7 +261,11 @@ const Sections = ({
                                   } more)`
                             }
                             itemLimit={20}
-                            items={data?.about.map(item => item.displayName)}
+                            items={data?.about.map(about => ({
+                              name: about.displayName,
+                              value: about.displayName,
+                              field: 'about.displayName',
+                            }))}
                           />
                         </OverviewSectionWrapper>
                       )}
@@ -313,7 +316,6 @@ const Sections = ({
               <Skeleton isLoaded={!isLoading}>
                 {data?.keywords && data?.keywords?.length > 0 && (
                   <SearchableItems
-                    fieldName='keywords'
                     generateButtonLabel={(
                       limit,
                       length,
@@ -324,7 +326,11 @@ const Sections = ({
                         : `Show all ${itemLabel} (${length - limit} more)`
                     }
                     itemLimit={20}
-                    items={data?.keywords}
+                    items={data?.keywords.map(kw => ({
+                      name: kw,
+                      value: kw,
+                      field: 'keywords',
+                    }))}
                   />
                 )}
               </Skeleton>
@@ -335,7 +341,6 @@ const Sections = ({
                 {data?.applicationCategory &&
                   data?.applicationCategory?.length > 0 && (
                     <SearchableItems
-                      fieldName='applicationCategory'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -346,7 +351,11 @@ const Sections = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={10}
-                      items={data?.applicationCategory}
+                      items={data?.applicationCategory.map(ac => ({
+                        name: ac,
+                        value: ac,
+                        field: 'applicationCategory',
+                      }))}
                     />
                   )}
               </Skeleton>
@@ -357,7 +366,6 @@ const Sections = ({
                 {data?.programmingLanguage &&
                   data?.programmingLanguage?.length > 0 && (
                     <SearchableItems
-                      fieldName='programmingLanguage'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -367,7 +375,11 @@ const Sections = ({
                           ? `Show fewer ${itemLabel}`
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
-                      items={data?.programmingLanguage}
+                      items={data?.programmingLanguage.map(pl => ({
+                        name: pl,
+                        value: pl,
+                        field: 'programmingLanguage',
+                      }))}
                       itemLimit={10}
                     />
                   )}

--- a/src/components/searchable-items/index.tsx
+++ b/src/components/searchable-items/index.tsx
@@ -5,10 +5,13 @@ import { ScrollContainer } from 'src/components/scroll-container';
 import { TagWithUrl } from 'src/components/tag-with-url';
 
 interface SearchableItemsProps extends FlexProps {
+  items: {
+    name: string;
+    value: string;
+    field: string;
+  }[];
   colorScheme?: TagProps['colorScheme'];
-  fieldName: string;
   generateButtonLabel?: (limit: number, length: number) => string;
-  items: string[] | null | undefined;
   itemLimit?: number;
   name?: React.ReactNode;
 }
@@ -26,7 +29,6 @@ const generateDefaultLabel = (limit: number, length: number) => {
  */
 export const SearchableItems: React.FC<SearchableItemsProps> = ({
   colorScheme = 'primary',
-  fieldName,
   generateButtonLabel = generateDefaultLabel,
   itemLimit = 3,
   items,
@@ -36,7 +38,7 @@ export const SearchableItems: React.FC<SearchableItemsProps> = ({
   const uniqueItems = useMemo(
     () =>
       Array.from(new Set(items ?? [])).sort((a, b) =>
-        a.localeCompare(b, undefined, { sensitivity: 'base' }),
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
       ),
     [items],
   );
@@ -65,18 +67,18 @@ export const SearchableItems: React.FC<SearchableItemsProps> = ({
       {name}
       {uniqueItems.slice(0, limit).map(item => (
         <TagWithUrl
-          key={item}
+          key={item.value}
           colorScheme={colorScheme}
           href={{
             pathname: '/search',
             query: {
-              q: `${fieldName}:"${item.trim().toLowerCase()}"`,
+              q: `${item.field}:"${item.value}"`,
             },
           }}
           m={0.5}
           leftIcon={FaMagnifyingGlass}
         >
-          {item}
+          {item.name}
         </TagWithUrl>
       ))}
       {uniqueItems.length > itemLimit && (

--- a/src/views/draft-search/components/results-list/components/card/index.tsx
+++ b/src/views/draft-search/components/results-list/components/card/index.tsx
@@ -451,7 +451,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='programmingLanguage'
                       generateButtonLabel={(
                         limit,
                         length,

--- a/src/views/draft-search/components/results-list/components/card/index.tsx
+++ b/src/views/draft-search/components/results-list/components/card/index.tsx
@@ -367,7 +367,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='topicCategory.name'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -378,11 +377,16 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.topicCategory?.flatMap(
-                        (topic: { name?: string }) =>
-                          topic?.name && typeof topic.name === 'string'
-                            ? [topic.name]
-                            : [],
+                      items={(data?.topicCategory ?? []).flatMap(topic =>
+                        typeof topic?.name === 'string'
+                          ? [
+                              {
+                                name: topic.name,
+                                value: topic.name,
+                                field: 'topicCategory.name',
+                              },
+                            ]
+                          : [],
                       )}
                       name={
                         <InfoLabel
@@ -408,7 +412,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='applicationCategory'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -419,7 +422,11 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.applicationCategory}
+                      items={data?.applicationCategory.map(ac => ({
+                        name: ac,
+                        value: ac,
+                        field: 'applicationCategory',
+                      }))}
                       name={
                         <InfoLabel
                           title='Application Categories'
@@ -455,7 +462,11 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.programmingLanguage}
+                      items={data?.programmingLanguage.map(pl => ({
+                        name: pl,
+                        value: pl,
+                        field: 'programmingLanguage',
+                      }))}
                       name={
                         <InfoLabel
                           title='Programming Languages'

--- a/src/views/draft-search/components/results-list/components/compact-card/index.tsx
+++ b/src/views/draft-search/components/results-list/components/compact-card/index.tsx
@@ -64,7 +64,12 @@ export const CompactCard = ({
 
   // Transform about array to string array for SearchableItems
   const aboutItems = useMemo(
-    () => about?.map(item => item.displayName) || [],
+    () =>
+      about?.map(a => ({
+        name: a.displayName,
+        value: a.displayName,
+        field: 'about.displayName',
+      })) || [],
     [about],
   );
 
@@ -211,7 +216,6 @@ export const CompactCard = ({
               <MetadataLabel label='Content Types' />
               <ScrollContainer overflow='auto' maxHeight='200px'>
                 <SearchableItems
-                  fieldName='about.displayName'
                   items={aboutItems}
                   itemLimit={2}
                   colorScheme='primary'

--- a/src/views/search-results-page/components/card/index.tsx
+++ b/src/views/search-results-page/components/card/index.tsx
@@ -361,7 +361,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='topicCategory.name'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -372,11 +371,16 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.topicCategory?.flatMap(
-                        (topic: { name?: string }) =>
-                          topic?.name && typeof topic.name === 'string'
-                            ? [topic.name]
-                            : [],
+                      items={(data?.topicCategory ?? []).flatMap(topic =>
+                        typeof topic?.name === 'string'
+                          ? [
+                              {
+                                name: topic.name,
+                                value: topic.name,
+                                field: 'topicCategory.name',
+                              },
+                            ]
+                          : [],
                       )}
                       name={
                         <InfoLabel
@@ -402,7 +406,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='applicationCategory'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -413,7 +416,11 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.applicationCategory}
+                      items={data?.applicationCategory.map(ac => ({
+                        name: ac,
+                        value: ac,
+                        field: 'applicationCategory',
+                      }))}
                       name={
                         <InfoLabel
                           title='Application Categories'
@@ -438,7 +445,6 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                     py={1}
                   >
                     <SearchableItems
-                      fieldName='programmingLanguage'
                       generateButtonLabel={(
                         limit,
                         length,
@@ -449,7 +455,11 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({
                           : `Show all ${itemLabel} (${length - limit} more)`
                       }
                       itemLimit={3}
-                      items={data.programmingLanguage}
+                      items={data?.programmingLanguage.map(pl => ({
+                        name: pl,
+                        value: pl,
+                        field: 'programmingLanguage',
+                      }))}
                       name={
                         <InfoLabel
                           title='Programming Languages'


### PR DESCRIPTION
Allows passing items with `name`, `value`, and `field` props to improve reusability.
