### PR TITLE
fix: correct feature list keyed searches

### DIFF
--- a/src/components/metadata/helpers.ts
+++ b/src/components/metadata/helpers.ts
@@ -300,7 +300,7 @@ const createFeatureListContent = (
               name,
               searchProps: {
                 ['aria-label']: `Search for results with feature "${name}"`,
-                property: 'feature.name',
+                property: 'featureList.name',
                 value: Array.isArray(feature.name)
                   ? feature.name.join('" OR "')
                   : feature.name,


### PR DESCRIPTION
# Summary

This PR fixes `featureList` keyed searches to ensure they yield results. 

Related issue: #357 