### PR TITLE
feature-261-sample-table

### DIFF
--- a/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
+++ b/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from '@chakra-ui/react';
+import { SampleTable } from '../SampleTable';
+import { Cell } from '../SampleTable/Cells';
+import { useSampleCollectionItems } from '../../hooks/useSampleCollectionItems';
+import {
+  getSampleCollectionItemsColumns,
+  getSampleCollectionItemsRows,
+} from '../../helpers';
+
+interface SampleCollectionItemsTableProps {
+  /** The identifier of the parent Dataset/SampleCollection used for the API query. */
+  parentIdentifier: string;
+}
+
+export const SampleCollectionItemsTable = ({
+  parentIdentifier,
+}: SampleCollectionItemsTableProps) => {
+  const { data: samples, isLoading } = useSampleCollectionItems(
+    parentIdentifier,
+    true,
+  );
+
+  // While loading show a skeleton that matches the page style.
+  if (isLoading) {
+    return (
+      <>
+        <Skeleton height='32px' mb={2} borderRadius='md' />
+        <Skeleton height='32px' mb={2} borderRadius='md' />
+        <Skeleton height='32px' mb={2} borderRadius='md' />
+        <Skeleton height='32px' borderRadius='md' />
+      </>
+    );
+  }
+
+  if (!samples || samples.length === 0) {
+    return null;
+  }
+
+  const columns = getSampleCollectionItemsColumns(samples);
+  const rows = getSampleCollectionItemsRows(samples);
+
+  return (
+    <SampleTable
+      label='Sample Collection Items Table'
+      caption={`${samples.length} sample${
+        samples.length !== 1 ? 's' : ''
+      } in this collection`}
+      tableProps={{
+        columns,
+        data: rows,
+        getCells: props => {
+          const data = props.data?.[props.column.property];
+          return Cell.renderCellData?.({ ...props, data });
+        },
+        hasPagination: true,
+      }}
+    />
+  );
+};

--- a/src/components/resource-sections/components/samples/config.ts
+++ b/src/components/resource-sections/components/samples/config.ts
@@ -12,8 +12,16 @@ export type SamplePropertyConfig = {
 
 export const SAMPLE_AGGREGATE_COLUMNS: SamplePropertyConfig[] = [
   {
+    key: 'alternateIdentifier',
+    includedProperties: ['alternateIdentifier'],
+  },
+  {
     key: 'anatomicalStructure',
     includedProperties: ['anatomicalStructure'],
+  },
+  {
+    key: 'anatomicalSystem',
+    includedProperties: ['anatomicalSystem'],
   },
   {
     key: 'associatedGenotype',
@@ -23,11 +31,17 @@ export const SAMPLE_AGGREGATE_COLUMNS: SamplePropertyConfig[] = [
     key: 'associatedPhenotype',
     includedProperties: ['associatedPhenotype'],
   },
-  { key: 'cellType', includedProperties: ['cellType'] },
-
+  {
+    key: 'cellType',
+    includedProperties: ['cellType'],
+  },
   {
     key: 'developmentalStage',
     includedProperties: ['developmentalStage'],
+  },
+  {
+    key: 'environmentalSystem',
+    includedProperties: ['environmentalSystem'],
   },
   {
     key: 'sampleAvailability',
@@ -38,10 +52,29 @@ export const SAMPLE_AGGREGATE_COLUMNS: SamplePropertyConfig[] = [
     includedProperties: ['sampleQuantity'],
   },
   {
+    key: 'sampleState',
+    includedProperties: ['sampleState'],
+  },
+  {
     key: 'sampleType',
     includedProperties: ['sampleType'],
   },
-  { key: 'sex', includedProperties: ['sex'] },
+  {
+    key: 'sex',
+    includedProperties: ['sex'],
+  },
+  {
+    key: 'healthCondition',
+    includedProperties: ['healthCondition'],
+  },
+  {
+    key: 'infectiousAgent',
+    includedProperties: ['infectiousAgent'],
+  },
+  {
+    key: 'species',
+    includedProperties: ['species'],
+  },
 ];
 
 export const SAMPLE_COLLECTION_COLUMNS: SamplePropertyConfig[] = [

--- a/src/components/resource-sections/components/samples/helpers.test.ts
+++ b/src/components/resource-sections/components/samples/helpers.test.ts
@@ -262,6 +262,51 @@ describe('helpers', () => {
       // fields are present with the correct values.
       expect(rows[0]).toMatchObject({ species: 'human', cellType: 'neuron' });
     });
+
+    it('flattens additionalProperty array into namespaced keys', () => {
+      const samples = [
+        {
+          identifier: 'S1',
+          additionalProperty: [
+            { propertyID: 'cell_type', value: 'CD138+ plasma' },
+            { propertyID: 'disease_state', value: 'tumor' },
+          ],
+        },
+      ] as any[];
+
+      const rows = getSampleCollectionItemsRows(samples);
+
+      expect(rows[0]['additionalProperty__cell_type']).toBe('CD138+ plasma');
+      expect(rows[0]['additionalProperty__disease_state']).toBe('tumor');
+    });
+
+    it('normalizes a single additionalProperty object (non-array) into a namespaced key', () => {
+      // The API can return a single object instead of an array.
+      const samples = [
+        {
+          identifier: 'S1',
+          additionalProperty: {
+            propertyID: 'cell_type',
+            value: 'CD138+ plasma',
+          },
+        },
+      ] as any[];
+
+      const rows = getSampleCollectionItemsRows(samples);
+
+      expect(rows[0]['additionalProperty__cell_type']).toBe('CD138+ plasma');
+    });
+
+    it('adds no additionalProperty keys when additionalProperty is absent', () => {
+      const samples = [{ identifier: 'S1' }] as any[];
+
+      const rows = getSampleCollectionItemsRows(samples);
+
+      const additionalKeys = Object.keys(rows[0]).filter(k =>
+        k.startsWith('additionalProperty__'),
+      );
+      expect(additionalKeys).toHaveLength(0);
+    });
   });
 
   describe('getSampleCollectionItemsColumns', () => {

--- a/src/components/resource-sections/components/samples/helpers.test.ts
+++ b/src/components/resource-sections/components/samples/helpers.test.ts
@@ -51,6 +51,14 @@ jest.mock('./config', () => ({
       key: 'species',
       includedProperties: ['species'],
     },
+    {
+      key: 'infectiousAgent',
+      includedProperties: ['infectiousAgent'],
+    },
+    {
+      key: 'healthCondition',
+      includedProperties: ['healthCondition'],
+    },
   ],
 }));
 
@@ -373,6 +381,54 @@ describe('helpers', () => {
       const props = cols.map(c => c.property);
 
       expect(props).toContain('species');
+    });
+
+    it('excludes infectiousAgent when all values are uniform', () => {
+      const samples = [
+        { identifier: 'S1', infectiousAgent: [{ name: 'SARS-CoV-2' }] },
+        { identifier: 'S2', infectiousAgent: [{ name: 'SARS-CoV-2' }] },
+      ] as any[];
+
+      const cols = getSampleCollectionItemsColumns(samples);
+      const props = cols.map(c => c.property);
+
+      expect(props).not.toContain('infectiousAgent');
+    });
+
+    it('includes infectiousAgent when values differ across samples', () => {
+      const samples = [
+        { identifier: 'S1', infectiousAgent: [{ name: 'SARS-CoV-2' }] },
+        { identifier: 'S2', infectiousAgent: [{ name: 'Influenza A' }] },
+      ] as any[];
+
+      const cols = getSampleCollectionItemsColumns(samples);
+      const props = cols.map(c => c.property);
+
+      expect(props).toContain('infectiousAgent');
+    });
+
+    it('excludes healthCondition when all values are uniform', () => {
+      const samples = [
+        { identifier: 'S1', healthCondition: [{ name: 'Healthy' }] },
+        { identifier: 'S2', healthCondition: [{ name: 'Healthy' }] },
+      ] as any[];
+
+      const cols = getSampleCollectionItemsColumns(samples);
+      const props = cols.map(c => c.property);
+
+      expect(props).not.toContain('healthCondition');
+    });
+
+    it('includes healthCondition when values differ across samples', () => {
+      const samples = [
+        { identifier: 'S1', healthCondition: [{ name: 'Healthy' }] },
+        { identifier: 'S2', healthCondition: [{ name: 'Tumor' }] },
+      ] as any[];
+
+      const cols = getSampleCollectionItemsColumns(samples);
+      const props = cols.map(c => c.property);
+
+      expect(props).toContain('healthCondition');
     });
 
     it('places non-uniform columns before uniform ones (after Sample ID)', () => {

--- a/src/components/resource-sections/components/samples/helpers.test.ts
+++ b/src/components/resource-sections/components/samples/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   formatUnitText,
   formatNumericValue,
   formatTerm,
+  formatPropertyId,
   getAvailableSamplePropertyColumns,
   getSampleCollectionItemsColumns,
   getSampleCollectionItemsRows,
@@ -109,6 +110,26 @@ describe('helpers', () => {
 
     it('returns empty string for empty input', () => {
       expect(formatTerm('')).toBe('');
+    });
+  });
+
+  describe('formatPropertyId', () => {
+    it('capitalizes each word and joins with spaces', () => {
+      expect(formatPropertyId('cell_type')).toBe('Cell Type');
+      expect(formatPropertyId('disease_state')).toBe('Disease State');
+    });
+
+    it('handles a single word with no underscores', () => {
+      expect(formatPropertyId('genomic')).toBe('Genomic');
+    });
+
+    it('normalizes mixed-case input — each word is title-cased', () => {
+      expect(formatPropertyId('CELL_TYPE')).toBe('Cell Type');
+      expect(formatPropertyId('cElL_tYpE')).toBe('Cell Type');
+    });
+
+    it('handles an empty string without throwing', () => {
+      expect(formatPropertyId('')).toBe('');
     });
   });
 

--- a/src/components/resource-sections/components/samples/helpers.ts
+++ b/src/components/resource-sections/components/samples/helpers.ts
@@ -2,7 +2,11 @@ import {
   getValueByPath,
   hasNonEmptyValue,
 } from 'src/components/resource-sections/helpers';
-import { SampleAggregate, SampleCollection } from 'src/utils/api/types';
+import {
+  AdditionalProperty,
+  SampleAggregate,
+  SampleCollection,
+} from 'src/utils/api/types';
 import { formatSampleLabelFromProperty } from 'src/utils/formatting/formatSample';
 import { Column } from 'src/components/table';
 import { SAMPLE_AGGREGATE_COLUMNS } from './config';
@@ -62,6 +66,52 @@ export const formatNumericValue = ({
 export const formatTerm = (term: string) =>
   term.charAt(0).toUpperCase() + term.slice(1);
 
+/**
+ * Format a propertyID string into a human-readable column title.
+ * Replace underscores with spaces and capitalize each word.
+ */
+export const formatPropertyId = (propertyId: string): string =>
+  propertyId
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+
+/**
+ * Namespaced column property key for an additionalProperty entry.
+ * Using a prefix guarantees no collision with top-level SampleAggregate fields.
+ */
+const ADDITIONAL_PROPERTY_PREFIX = 'additionalProperty__' as const;
+
+type AdditionalPropertyColumnKey =
+  `${typeof ADDITIONAL_PROPERTY_PREFIX}${string}`;
+
+const toAdditionalPropertyKey = (
+  propertyId: string,
+): AdditionalPropertyColumnKey => `${ADDITIONAL_PROPERTY_PREFIX}${propertyId}`;
+
+/**
+ * Normalize additionalProperty to always be an array.
+ * The API can return either a single object or an array depending on the record.
+ */
+const normalizeAdditionalProperty = (
+  sample: SampleAggregate,
+): AdditionalProperty[] => {
+  const raw = sample.additionalProperty;
+  if (!raw) return [];
+  return Array.isArray(raw) ? raw : [raw];
+};
+
+/**
+ * Retrieve the value for a given propertyID from a sample's
+ * additionalProperty array, or undefined if absent.
+ */
+const getAdditionalPropertyValue = (
+  sample: SampleAggregate,
+  propertyId: string,
+): AdditionalProperty['value'] | undefined =>
+  normalizeAdditionalProperty(sample).find(p => p.propertyID === propertyId)
+    ?.value;
+
 interface SamplePropertyColumns extends Column {
   values: any;
   includedProperties: string[];
@@ -70,7 +120,7 @@ interface SamplePropertyColumns extends Column {
 
 /*
  * Generate table rows based on available sample properties.
- * Only includes rows where at least one configured property has a non-empty value.
+ * Only include rows where at least one configured property has a non-empty value.
  */
 export const getAvailableSamplePropertyColumns = (
   data: SampleAggregate | SampleCollection,
@@ -105,8 +155,7 @@ export const getAvailableSamplePropertyColumns = (
 
 /**
  * Produce a key for a DefinedTerm-like value used for
- * sameness comparison. Use identifier
- * when present, fall back to name.
+ * sameness comparison. Use identifier when present, fall back to name.
  */
 const termKey = (
   term: { identifier?: string; name?: string } | string,
@@ -118,7 +167,7 @@ const termKey = (
 /**
  * Produce a stable string representing the full value of a field on one sample.
  * Arrays are sorted so element-order differences don't count as "different".
- * Return a special marker for null/undefined to distinguish from empty strings.
+ * Returns a special marker for null/undefined to distinguish from empty strings.
  */
 const fieldSignature = (value: unknown): string => {
   if (value == null) return '__NULL__';
@@ -152,11 +201,11 @@ const fieldSignature = (value: unknown): string => {
         value.map(item => {
           if (item != null && typeof item === 'object') {
             // Sort keys for stable comparison
-            const sorted: any = {};
+            const sorted: Record<string, unknown> = {};
             Object.keys(item)
               .sort()
               .forEach(key => {
-                sorted[key] = (item as any)[key];
+                sorted[key] = (item as Record<string, unknown>)[key];
               });
             return sorted;
           }
@@ -179,11 +228,11 @@ const fieldSignature = (value: unknown): string => {
 
     // For complex objects, use full JSON comparison
     try {
-      const sorted: any = {};
+      const sorted: Record<string, unknown> = {};
       Object.keys(value)
         .sort()
         .forEach(key => {
-          sorted[key] = (value as any)[key];
+          sorted[key] = (value as Record<string, unknown>)[key];
         });
       return JSON.stringify(sorted);
     } catch {
@@ -205,17 +254,31 @@ const UNIFORM_HIDE_PROPS = new Set<string>([
 ]);
 
 /**
+ * Collect all distinct propertyIDs that appear across the given samples.
+ */
+const collectAdditionalPropertyIds = (samples: SampleAggregate[]): string[] => [
+  ...new Set(
+    samples.flatMap(sample =>
+      normalizeAdditionalProperty(sample).map(p => p.propertyID),
+    ),
+  ),
+];
+
+/**
  * Build the columns array for the fetched SampleCollection items table.
  *
  * Rules applied:
- *   R1. Omit any column where no sample has a value
+ *   R1. Omit any column where no sample has a value.
  *   R2. Omit healthCondition / infectiousAgent / species when all values
- *       are identical across samples
+ *       are identical across samples.
+ *   R3. additionalProperty columns: shown only when values differ across
+ *       samples (same rule as UNIFORM_HIDE_PROPS); hidden when uniform.
  *
  * Column ordering:
  *   1. Sample ID
- *   2. Columns with non-uniform values (sorted alphabetically by display title)
- *   3. Columns with uniform values (sorted alphabetically by display title)
+ *   2. Non-uniform columns (sorted alphabetically by display title)
+ *   3. Uniform columns (sorted alphabetically by display title)
+ *   4. Non-uniform additionalProperty columns (sorted alphabetically by title)
  *
  */
 export const getSampleCollectionItemsColumns = (
@@ -266,11 +329,28 @@ export const getSampleCollectionItemsColumns = (
   nonUniformColumns.sort((a, b) => a.title.localeCompare(b.title));
   uniformColumns.sort((a, b) => a.title.localeCompare(b.title));
 
-  // Assemble final columns: Sample ID, then non-uniform, then uniform.
+  // For each distinct propertyID, apply the same uniform-hide rule:
+  // render a column only when at least one sample differs (including missing = __NULL__).
+  const additionalPropertyColumns: Array<{ title: string; property: string }> =
+    collectAdditionalPropertyIds(samples)
+      .filter(propertyId => {
+        const signatures = samples.map(sample =>
+          fieldSignature(getAdditionalPropertyValue(sample, propertyId)),
+        );
+        return !signatures.every(sig => sig === signatures[0]);
+      })
+      .map(propertyId => ({
+        title: formatPropertyId(propertyId),
+        property: toAdditionalPropertyKey(propertyId),
+      }))
+      .sort((a, b) => a.title.localeCompare(b.title));
+
+  // Assemble final columns: Sample ID, non-uniform, uniform, additionalProperty.
   return [
     { title: 'Sample ID', property: 'identifier', isSortable: true },
     ...nonUniformColumns.map(col => ({ ...col, isSortable: false })),
     ...uniformColumns.map(col => ({ ...col, isSortable: false })),
+    ...additionalPropertyColumns.map(col => ({ ...col, isSortable: false })),
   ];
 };
 
@@ -278,15 +358,28 @@ export const getSampleCollectionItemsColumns = (
  * Build the rows array for the fetched SampleCollection items table.
  * The `identifier` field is shaped as `{ identifier, url }` so the existing
  * DefinedTermCell renderer can display it as an external link.
+ *
+ * Each `additionalProperty` entry is flattened into the row under the
+ * namespaced key `additionalProperty__<propertyID>` so the column renderer
+ * can pick it up via `props.data?.[props.column.property]`.
  */
 export const getSampleCollectionItemsRows = (
   samples: SampleAggregate[],
-): Record<string, unknown>[] => {
-  return samples.map(sample => ({
-    ...sample,
-    identifier: {
-      identifier: sample.identifier ?? (sample as any)._id,
-      url: (sample as any).url ?? '',
-    },
-  }));
-};
+): Record<string, unknown>[] =>
+  samples.map(sample => {
+    const additionalPropertyEntries = Object.fromEntries(
+      normalizeAdditionalProperty(sample).map(({ propertyID, value }) => [
+        toAdditionalPropertyKey(propertyID),
+        value,
+      ]),
+    );
+
+    return {
+      ...sample,
+      identifier: {
+        identifier: sample.identifier ?? (sample as any)._id,
+        url: sample.url ?? '',
+      },
+      ...additionalPropertyEntries,
+    };
+  });

--- a/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.test.ts
+++ b/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.test.ts
@@ -54,7 +54,7 @@ describe('fetchSamplesByParentIdentifier', () => {
       'http://localhost:3000/query',
       {
         params: {
-          q: 'isPartOf.identifier:"parent-123" AND @type:"Sample"',
+          q: 'isBasisFor.identifier:"parent-123" AND @type:"Sample"',
           size: 1000,
         },
       },

--- a/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.test.ts
+++ b/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.test.ts
@@ -1,0 +1,177 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import axios from 'axios';
+import React from 'react';
+import {
+  fetchSamplesByParentIdentifier,
+  useSampleCollectionItems,
+} from './useSampleCollectionItems';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Store the original value so it can be restored after tests that modify it.
+const ORIGINAL_API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+// Creates a fresh QueryClient and wrapper for each test to prevent later
+// tests to receive cached data from earlier ones.
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('fetchSamplesByParentIdentifier', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3000';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = ORIGINAL_API_URL;
+    jest.clearAllMocks();
+  });
+
+  it('throws when NEXT_PUBLIC_API_URL is not defined', async () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    await expect(fetchSamplesByParentIdentifier('parent-123')).rejects.toThrow(
+      'API URL is undefined',
+    );
+  });
+
+  it('calls the correct endpoint with the correct query params', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { hits: [] } });
+
+    await fetchSamplesByParentIdentifier('parent-123');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'http://localhost:3000/query',
+      {
+        params: {
+          q: 'isPartOf.identifier:"parent-123" AND @type:"Sample"',
+          size: 1000,
+        },
+      },
+    );
+  });
+
+  it('returns an empty array when hits is empty', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { hits: [] } });
+
+    const result = await fetchSamplesByParentIdentifier('parent-123');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when hits is missing from the response', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: {} });
+
+    const result = await fetchSamplesByParentIdentifier('parent-123');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns the hits array when samples are found', async () => {
+    const mockSamples = [
+      { identifier: 'S1', '@type': 'Sample' },
+      { identifier: 'S2', '@type': 'Sample' },
+    ];
+    mockedAxios.get.mockResolvedValueOnce({ data: { hits: mockSamples } });
+
+    const result = await fetchSamplesByParentIdentifier('parent-123');
+
+    expect(result).toEqual(mockSamples);
+  });
+});
+
+describe('useSampleCollectionItems', () => {
+  // Set the API URL in beforeEach rather than inside individual tests.
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3000';
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = ORIGINAL_API_URL;
+  });
+
+  it('does not fetch when enabled is false', () => {
+    renderHook(() => useSampleCollectionItems('parent-123', false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when parentIdentifier is undefined', () => {
+    renderHook(() => useSampleCollectionItems(undefined, true), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns samples when enabled and parentIdentifier are provided', async () => {
+    const mockSamples = [{ identifier: 'S1', '@type': 'Sample' }];
+    mockedAxios.get.mockResolvedValueOnce({ data: { hits: mockSamples } });
+
+    const { result } = renderHook(
+      () => useSampleCollectionItems('parent-123', true),
+      { wrapper: createWrapper() },
+    );
+
+    // Wait for the query to finish loading before asserting on the data,
+    // since useQuery is asynchronous and data won't be available immediately
+    // after the hook renders.
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(mockSamples);
+  });
+
+  it('returns isLoading true while the request is in flight', () => {
+    // Never resolve so the hook stays in loading state for the duration
+    // of this test.
+    mockedAxios.get.mockReturnValueOnce(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useSampleCollectionItems('parent-123', true),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('uses the correct query key so results are cached per parentIdentifier', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { hits: [] } });
+
+    // Both hooks share the same wrapper instance so they use the same
+    // QueryClient. Using separate createWrapper() calls would give each hook
+    // its own client with its own cache, meaning the second hook would never
+    // see the result of the first hook's fetch and could time out waiting
+    // to resolve.
+    const wrapper = createWrapper();
+
+    const { result: result1 } = renderHook(
+      () => useSampleCollectionItems('parent-aaa', true),
+      { wrapper },
+    );
+    const { result: result2 } = renderHook(
+      () => useSampleCollectionItems('parent-bbb', true),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result1.current.isLoading).toBe(false));
+    await waitFor(() => expect(result2.current.isLoading).toBe(false));
+
+    // Each distinct parentIdentifier should trigger its own fetch since
+    // they map to different query keys: ['sample-collection-items',
+    // 'parent-aaa'] and ['sample-collection-items', 'parent-bbb'].
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.ts
+++ b/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.ts
@@ -8,7 +8,7 @@ export const fetchSamplesByParentIdentifier = async (
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
   if (!apiUrl) throw new Error('API URL is undefined');
 
-  const q = `isPartOf.identifier:"${parentIdentifier}" AND @type:"Sample"`;
+  const q = `isBasisFor.identifier:"${parentIdentifier}" AND @type:"Sample"`;
   const response = await axios.get(`${apiUrl}/query`, {
     params: { q, size: 1000 },
   });

--- a/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.ts
+++ b/src/components/resource-sections/components/samples/hooks/useSampleCollectionItems.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { SampleAggregate } from 'src/utils/api/types';
+
+export const fetchSamplesByParentIdentifier = async (
+  parentIdentifier: string,
+): Promise<SampleAggregate[]> => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) throw new Error('API URL is undefined');
+
+  const q = `isPartOf.identifier:"${parentIdentifier}" AND @type:"Sample"`;
+  const response = await axios.get(`${apiUrl}/query`, {
+    params: { q, size: 1000 },
+  });
+
+  const hits = response.data?.hits;
+  if (!hits || hits.length === 0) return [];
+  return hits as SampleAggregate[];
+};
+
+export const useSampleCollectionItems = (
+  parentIdentifier: string | undefined,
+  enabled: boolean,
+) => {
+  return useQuery<SampleAggregate[]>({
+    queryKey: ['sample-collection-items', parentIdentifier],
+    queryFn: () => fetchSamplesByParentIdentifier(parentIdentifier!),
+    enabled: enabled && Boolean(parentIdentifier),
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/components/resource-sections/components/samples/index.tsx
+++ b/src/components/resource-sections/components/samples/index.tsx
@@ -2,14 +2,16 @@ import { Box, Flex } from '@chakra-ui/react';
 import { SampleAggregate, SampleCollection } from 'src/utils/api/types';
 import { SampleTable } from './components/SampleTable';
 import { Cell } from './components/SampleTable/Cells';
-import { SAMPLE_COLLECTION_TABLE_CONFIG, SAMPLE_TABLE_CONFIG } from './config';
+import { SampleCollectionItemsTable } from './components/SampleCollectionsTable';
+import { SAMPLE_TABLE_CONFIG } from './config';
 import { TableProps } from 'src/components/table';
 
 interface SamplesDisplayProps {
   sample: SampleAggregate | SampleCollection | null | undefined;
+  resourceIdentifier?: string;
 }
 
-function renderTableWithConfig<T extends SampleAggregate | SampleCollection>(
+function renderSampleTable<T extends SampleAggregate>(
   sample: T,
   config: {
     label: string;
@@ -36,15 +38,29 @@ function renderTableWithConfig<T extends SampleAggregate | SampleCollection>(
   );
 }
 
-export const SamplesDisplay = ({ sample }: SamplesDisplayProps) => {
+export const SamplesDisplay = ({
+  sample,
+  resourceIdentifier,
+}: SamplesDisplayProps) => {
   if (!sample || !sample['@type']) return null;
 
   return (
     <Flex flexDirection='column' gap={8}>
       <Box>
-        {sample['@type'] === 'Sample'
-          ? renderTableWithConfig(sample, SAMPLE_TABLE_CONFIG)
-          : renderTableWithConfig(sample, SAMPLE_COLLECTION_TABLE_CONFIG)}
+        {sample['@type'] === 'Sample' ? (
+          renderSampleTable(sample as SampleAggregate, SAMPLE_TABLE_CONFIG)
+        ) : (
+          // SampleCollection: fetch individual sample records via the API and
+          // render them in a table.
+          <SampleCollectionItemsTable
+            parentIdentifier={
+              (sample as SampleCollection & { identifier?: string })
+                .identifier ??
+              resourceIdentifier ??
+              ''
+            }
+          />
+        )}
       </Box>
     </Flex>
   );

--- a/src/components/resource-sections/index.tsx
+++ b/src/components/resource-sections/index.tsx
@@ -388,6 +388,12 @@ const Sections = ({
                   )}
                 </>
               )}
+
+            {/* Show smaples */}
+            {section.hash === 'samples' && !SHOULD_HIDE_SAMPLES('samples') && (
+              <SamplesDisplay sample={data?.sample} />
+            )}
+
             {/* Show provenance */}
             {section.hash === 'provenance' && (
               <ResourceProvenance isLoading={isLoading} {...data} />
@@ -458,11 +464,6 @@ const Sections = ({
                   }
                 }
               />
-            )}
-
-            {/* Show provenance */}
-            {section.hash === 'samples' && !SHOULD_HIDE_SAMPLES('samples') && (
-              <SamplesDisplay sample={data?.sample} />
             )}
 
             {/* Show raw metadata */}

--- a/src/components/resource-sections/index.tsx
+++ b/src/components/resource-sections/index.tsx
@@ -391,7 +391,10 @@ const Sections = ({
 
             {/* Show smaples */}
             {section.hash === 'samples' && !SHOULD_HIDE_SAMPLES('samples') && (
-              <SamplesDisplay sample={data?.sample} />
+              <SamplesDisplay
+                sample={data?.sample}
+                resourceIdentifier={data?.identifier ?? undefined}
+              />
             )}
 
             {/* Show provenance */}

--- a/src/components/resource-sections/resource-sections.json
+++ b/src/components/resource-sections/resource-sections.json
@@ -71,6 +71,16 @@
       }
     },
     {
+      "title": "Samples",
+      "hash": "samples",
+      "properties": ["sample", "sample.numberOfItems", "sample.sampleQuantity"],
+      "ui": {
+        "isCollapsible": true,
+        "showInNavigation": true,
+        "showEmptyState": false
+      }
+    },
+    {
       "title": "Provenance",
       "hash": "provenance",
       "properties": ["includedInDataCatalog", "url", "sdPublisher"],
@@ -124,16 +134,6 @@
       "ui": {
         "isCollapsible": true,
         "showInNavigation": true
-      }
-    },
-    {
-      "title": "Samples",
-      "hash": "samples",
-      "properties": ["sample", "sample.numberOfItems", "sample.sampleQuantity"],
-      "ui": {
-        "isCollapsible": true,
-        "showInNavigation": true,
-        "showEmptyState": false
       }
     },
     {

--- a/src/utils/api/types.ts
+++ b/src/utils/api/types.ts
@@ -46,6 +46,12 @@ export type AccessTypes =
   | 'Varied'
   | 'Unknown';
 
+export interface AdditionalProperty {
+  '@type'?: 'PropertyValue';
+  propertyID: string;
+  value: string;
+}
+
 export interface AdditionalType {
   name?: string;
   url?: string;
@@ -391,6 +397,7 @@ export interface QuantitativeValue {
 
 export interface SampleAggregate {
   '@type': 'Sample';
+  additionalProperty?: AdditionalProperty | AdditionalProperty[];
   anatomicalStructure?: DefinedTerm[];
   anatomicalSystem?: DefinedTerm[];
   associatedGenotype?: (string | DefinedTerm)[];

--- a/src/utils/formatting/formatSample.ts
+++ b/src/utils/formatting/formatSample.ts
@@ -1,16 +1,23 @@
 export const SAMPLE_PROPERTY_LABELS: { [key: string]: { label: string } } = {
+  alternateIdentifier: { label: 'Alternate Identifer' },
   anatomicalStructure: { label: 'Anatomical Structure' },
+  anatomicalSystem: { label: 'Anatomical System' },
   associatedGenotype: { label: 'Associated Genotype' },
   associatedPhenotype: { label: 'Associated Phenotype' },
   cellType: { label: 'Cell Type' },
   developmentalStage: { label: 'Developmental Stage' },
+  environmentalSystem: { label: 'Environmental System' },
+  healthCondition: { label: 'Health Condition' },
+  identifier: { label: 'Sample ID' },
+  infectiousAgent: { label: 'Infectious Agent' },
+  itemListElement: { label: 'Sample Collection List' },
   numberOfItems: { label: 'Number of Samples' },
   sampleAvailability: { label: 'Sample Availability' },
-  identifier: { label: 'Sample ID' },
-  itemListElement: { label: 'Sample Collection List' },
   sampleQuantity: { label: 'Sample Quantity' },
+  sampleState: { label: 'Sample State' },
   sampleType: { label: 'Sample Type' },
   sex: { label: 'Sex' },
+  species: { label: 'Species' },
 };
 
 export const formatSampleLabelFromProperty = (property: string) => {


### PR DESCRIPTION
# Summary

This PR modifies the location of the `Samples section` (Resource page) and populates the sample table with sample-level metadata.

Please refer to https://github.com/NIAID-Data-Ecosystem/niaid-feedback/issues/261#event-22596856469 for further information.