### PR TITLE
bugfix-231-sample-table-controls

### DIFF
--- a/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
+++ b/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
@@ -49,7 +49,14 @@ export const SampleCollectionItemsTable = ({
         columns,
         data: rows,
         getCells: props => {
-          const data = props.data?.[props.column.property];
+          // The Sample ID column sorts by '_identifierSort' (a plain string)
+          // but must render using 'identifier' (the { identifier, url }
+          // object) so that the link cell displays correctly.
+          const property =
+            props.column.property === '_identifierSort'
+              ? 'identifier'
+              : props.column.property;
+          const data = props.data?.[property];
           return Cell.renderCellData?.({ ...props, data });
         },
         hasPagination: true,

--- a/src/components/resource-sections/components/samples/helpers.test.ts
+++ b/src/components/resource-sections/components/samples/helpers.test.ts
@@ -257,6 +257,7 @@ describe('helpers', () => {
         identifier: 'fallback-id',
         url: '',
       });
+      expect(rows[0]._identifierSort).toBe('fallback-id');
     });
 
     it('preserves other sample fields on the row', () => {
@@ -315,6 +316,18 @@ describe('helpers', () => {
       );
       expect(additionalKeys).toHaveLength(0);
     });
+
+    it('adds _identifierSort as a plain string matching the identifier', () => {
+      const samples = [
+        { identifier: 'S1', url: 'https://example.com' },
+        { identifier: 'S2', url: '' },
+      ] as any[];
+
+      const rows = getSampleCollectionItemsRows(samples);
+
+      expect(rows[0]._identifierSort).toBe('S1');
+      expect(rows[1]._identifierSort).toBe('S2');
+    });
   });
 
   describe('getSampleCollectionItemsColumns', () => {
@@ -329,13 +342,18 @@ describe('helpers', () => {
     });
 
     it('always includes Sample ID as the first column', () => {
+      // The Sample ID column uses '_identifierSort' (a plain string field on
+      // each row) as its property so that useTableSort compares strings rather
+      // than the { identifier, url } object used for rendering. The
+      // SampleCollectionItemsTable getCells callback remaps '_identifierSort'
+      // back to 'identifier' when reading the row for display.
       const samples = [{ identifier: 'S1' }] as any[];
 
       const cols = getSampleCollectionItemsColumns(samples);
 
       expect(cols[0]).toEqual({
         title: 'Sample ID',
-        property: 'identifier',
+        property: '_identifierSort',
         isSortable: true,
       });
     });

--- a/src/components/resource-sections/components/samples/helpers.ts
+++ b/src/components/resource-sections/components/samples/helpers.ts
@@ -345,9 +345,15 @@ export const getSampleCollectionItemsColumns = (
       }))
       .sort((a, b) => a.title.localeCompare(b.title));
 
-  // Assemble final columns: Sample ID, non-uniform, uniform, additionalProperty.
+  // Assemble final columns: Sample ID, non-uniform, uniform,
+  // additionalProperty. property points at '_identifierSort'
+  // (a plain string field added to each row) so that useTableSort
+  // can compare strings instead of the { identifier, url }
+  // object that is used for rendering. The SampleCollectionItemsTable
+  // getCells callback remaps '_identifierSort' back to 'identifier'
+  // when reading the row.
   return [
-    { title: 'Sample ID', property: 'identifier', isSortable: true },
+    { title: 'Sample ID', property: '_identifierSort', isSortable: true },
     ...nonUniformColumns.map(col => ({ ...col, isSortable: false })),
     ...uniformColumns.map(col => ({ ...col, isSortable: false })),
     ...additionalPropertyColumns.map(col => ({ ...col, isSortable: false })),
@@ -362,6 +368,10 @@ export const getSampleCollectionItemsColumns = (
  * Each `additionalProperty` entry is flattened into the row under the
  * namespaced key `additionalProperty__<propertyID>` so the column renderer
  * can pick it up via `props.data?.[props.column.property]`.
+ *
+ * `_identifierSort` is a plain string copy of the identifier used exclusively
+ * for sorting (avoids comparing { identifier, url } objects as
+ * "[object Object]").
  */
 export const getSampleCollectionItemsRows = (
   samples: SampleAggregate[],
@@ -380,6 +390,7 @@ export const getSampleCollectionItemsRows = (
         identifier: sample.identifier ?? (sample as any)._id,
         url: sample.url ?? '',
       },
+      _identifierSort: sample.identifier ?? (sample as any)._id ?? '',
       ...additionalPropertyEntries,
     };
   });


### PR DESCRIPTION
# Summary

This PR fixes an issue that prevented sample tables from being sorted correctly.