### PR TITLE
fix: handle QuantitativeValue and DefinedTerm fields

### DIFF
--- a/src/components/resource-sections/components/samples/components/SampleTable/Cells.tsx
+++ b/src/components/resource-sections/components/samples/components/SampleTable/Cells.tsx
@@ -29,14 +29,15 @@ const DefinedTermCell = ({ identifier, name, url }: DefinedTerm) => {
 const QuantitativeValueCell = ({
   maxValue,
   minValue,
+  name,
   unitText,
   value,
 }: QuantitativeValue) => {
-  const valueStr = formatNumericValue({
-    value,
-    minValue,
-    maxValue,
-  });
+  const valueStr = formatNumericValue({ value, minValue, maxValue });
+
+  // Fall back to `name` when no numeric value fields are present
+  // (e.g. { "@type": "QuantitativeValue", "name": "42 year" })
+  if (!valueStr && name) return <TextCell>{name}</TextCell>;
 
   if (!unitText) return <TextCell>{valueStr}</TextCell>;
   const unitStr = formatUnitText(unitText);
@@ -62,12 +63,19 @@ export const renderValue = (val: CellValue, key?: React.Key) => {
     return <TextCell key={key}>{formatTerm(val)}</TextCell>;
   }
 
-  if ('value' in val || 'minValue' in val || 'maxValue' in val) {
-    return <QuantitativeValueCell key={key} {...val} />;
+  // Check @type explicitly first so a QuantitativeValue with only a `name`
+  // field (and no value/minValue/maxValue) isn't misrouted to DefinedTermCell.
+  if (
+    (val as QuantitativeValue)['@type'] === 'QuantitativeValue' ||
+    'value' in val ||
+    'minValue' in val ||
+    'maxValue' in val
+  ) {
+    return <QuantitativeValueCell key={key} {...(val as QuantitativeValue)} />;
   }
 
   if ('name' in val || 'identifier' in val || 'url' in val) {
-    return <DefinedTermCell key={key} {...val} />;
+    return <DefinedTermCell key={key} {...(val as DefinedTerm)} />;
   }
 
   return null;

--- a/src/components/resource-sections/components/samples/helpers.ts
+++ b/src/components/resource-sections/components/samples/helpers.ts
@@ -63,8 +63,10 @@ export const formatNumericValue = ({
   return '';
 };
 
-export const formatTerm = (term: string) =>
-  term.charAt(0).toUpperCase() + term.slice(1);
+export const formatTerm = (term: string) => {
+  if (!term || typeof term !== 'string') return '';
+  return term.charAt(0).toUpperCase() + term.slice(1);
+};
 
 /**
  * Format a propertyID string into a human-readable column title.


### PR DESCRIPTION
# Summary

This PR improves the handling of `QuantitativeValue` and `DefinedTerm` fields when generating **Sample Tables** on the **Resource Page**.