### PR TITLE
bugfix active tab

### DIFF
--- a/src/views/search/components/results-list/components/carousel-compact-card/disease-overview-card/index.tsx
+++ b/src/views/search/components/results-list/components/carousel-compact-card/disease-overview-card/index.tsx
@@ -65,7 +65,7 @@ export const DiseaseOverviewCard = ({
           {/* Description (if present) */}
           {topicEmphasizedDescription || description ? (
             <>
-              <Text noOfLines={6} fontSize='xs' lineHeight='short'>
+              <Text as='div' noOfLines={6} fontSize='xs' lineHeight='short'>
                 {topicEmphasizedDescription ? (
                   <ReactMarkdown rehypePlugins={[rehypeRaw, remarkGfm]}>
                     {topicEmphasizedDescription}

--- a/src/views/search/components/search-results-tabs-controller/index.tsx
+++ b/src/views/search/components/search-results-tabs-controller/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { TabPanel } from '@chakra-ui/react';
 import { useSearchTabsContext } from '../../context/search-tabs-context';
@@ -46,9 +46,17 @@ export const SearchResultsController = ({
   const { selectedIndex, setSelectedIndex } = useSearchTabsContext();
   const { getPagination, setPagination } = usePaginationContext();
 
+  // Track if the user has chosen a tab. When set, the auto-tab will only
+  // override the user choice if there are no results for that tab.
+  const userSelectedTabRef = useRef<string | null>(null);
+
   const handleTabChange = (index: number) => {
     setSelectedIndex(index);
     const selectedTab = tabs[index];
+
+    // Record the user choice so the auto-tab respects it.
+    userSelectedTabRef.current = selectedTab.id;
+
     const paginationState = getPagination(selectedTab.id);
 
     setPagination(selectedTab.id, paginationState);
@@ -97,6 +105,25 @@ export const SearchResultsController = ({
     const selectedTypes: string[] = Array.isArray(typeFilter)
       ? typeFilter.filter((item): item is string => typeof item === 'string')
       : [];
+
+    // If the user has selected a tab, only leave it when that tab
+    // has no associated results anymore.
+    if (userSelectedTabRef.current !== null) {
+      const currentTab = tabs[selectedIndex];
+      const currentTabHasResults = currentTab?.types.some(({ type }) =>
+        facetCounts.some(f => f.type === type && f.count > 0),
+      );
+
+      if (currentTabHasResults) {
+        // The user's chosen tab still has associated results. The active tab
+        // remains the same.
+        return;
+      }
+
+      // No results for the chosen tab. Use the auto-tab to select the
+      // active tab.
+      userSelectedTabRef.current = null;
+    }
 
     // Determine the correct tab
     const calculatedTabId = getDefaultTabId(tabs, facetCounts, selectedTypes);


### PR DESCRIPTION
# Summary

This PR updates the logic for determining the active tab on the` Search Results` page to better reflect user selections.