### PR TITLE
feat: visual summary bar chart improvements

### DIFF
--- a/src/components/visualizations/bar/helpers.ts
+++ b/src/components/visualizations/bar/helpers.ts
@@ -1,7 +1,9 @@
-const NICE_MULTIPLIERS = [1, 2, 5, 10] as const;
+// Include 1.5 so ranges like 287,487 can land on 300,000 (step 150,000)
+// instead of jumping to 400,000 (step 200,000).
+const NICE_MULTIPLIERS = [1, 1.5, 2, 3, 5, 10] as const;
 
 function niceCeil(value: number) {
-  if (value <= 0) return 0;
+  if (value <= 0) return 1;
 
   const pow10 = Math.pow(10, Math.floor(Math.log10(value)));
   const scaled = value / pow10;
@@ -13,23 +15,9 @@ function niceCeil(value: number) {
   return m * pow10;
 }
 
-function niceStep(niceMax: number, targetTickCount: number) {
-  if (niceMax <= 0) return 1;
-
-  const rawStep = niceMax / Math.max(1, targetTickCount - 1);
-  const pow10 = Math.pow(10, Math.floor(Math.log10(rawStep)));
-  const scaled = rawStep / pow10;
-
-  const m =
-    NICE_MULTIPLIERS.find(mult => scaled <= mult) ??
-    NICE_MULTIPLIERS[NICE_MULTIPLIERS.length - 1];
-
-  return m * pow10;
-}
-
 export function makeNiceTicks({
   maxValue,
-  targetTickCount = 3,
+  targetTickCount,
 }: {
   maxValue: number;
   targetTickCount?: number;
@@ -37,16 +25,23 @@ export function makeNiceTicks({
   const max = Math.max(0, maxValue || 0);
   if (max === 0) return { niceMax: 0, tickValues: [0] };
 
-  // 1) always round UP
-  const niceMax = niceCeil(max);
+  const resolvedTickCount = targetTickCount ?? (max >= 100_000 ? 4 : 3);
 
-  // 2) derive step from niceMax
-  const step = niceStep(niceMax, targetTickCount);
+  // Derive a nice step from the data range, then round the domain max up to
+  // the nearest multiple of that step — keeps the axis tight to the data.
+  const rawStep = max / Math.max(1, resolvedTickCount - 1);
+  // Counts are whole numbers, so keep step/ticks as integers.
+  const step = Math.max(1, Math.ceil(niceCeil(rawStep)));
+  const niceMax = step * Math.ceil(max / step);
 
-  // 3) generate ticks
   const tickValues: number[] = [];
-  for (let v = 0; v <= niceMax + step / 2; v += step) {
-    tickValues.push(v);
+  const tickCount = Math.max(1, Math.round(niceMax / step));
+  for (let i = 0; i <= tickCount; i += 1) {
+    tickValues.push(i * step);
+  }
+
+  if (tickValues[tickValues.length - 1] !== niceMax) {
+    tickValues.push(niceMax);
   }
 
   return { niceMax, tickValues };

--- a/src/components/visualizations/bar/index.tsx
+++ b/src/components/visualizations/bar/index.tsx
@@ -314,13 +314,17 @@ export const BarChart = ({
                           pointerEvents: 'auto',
                           textAlign: labelStyles.horizontalAnchor,
                           width: `${maxLabelWidth}px`,
+                          overflow: 'hidden',
                         }}
                       >
                         <Text
                           color={id === MORE_ID ? 'link.color' : 'text.heading'}
-                          maxWidth={`${maxLabelWidth}px`}
+                          width='100%'
+                          display='block'
+                          overflow='hidden'
+                          textOverflow='ellipsis'
+                          whiteSpace='nowrap'
                           textDecoration={id === MORE_ID ? 'underline' : 'none'}
-                          noOfLines={1}
                           style={{ cursor: 'pointer' }}
                           onClick={e => {
                             e.stopPropagation();

--- a/src/components/visualizations/bar/index.tsx
+++ b/src/components/visualizations/bar/index.tsx
@@ -69,7 +69,7 @@ const getTermColor = (data: ChartDatum[]) =>
 export const BarChart = ({
   width: initialWidth = 400,
   height: initialHeight = 400,
-  margin = { top: 10, right: 40, bottom: 0, left: 0 },
+  margin = { top: 10, right: 30, bottom: 0, left: 0 },
   data,
   onSliceClick,
   isSliceSelected,

--- a/src/components/visualizations/bar/index.tsx
+++ b/src/components/visualizations/bar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Button, Flex, Text } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 import { useSpring, animated } from '@react-spring/web';
 import { Annotation, HtmlLabel } from '@visx/annotation';
 import { AxisBottom } from '@visx/axis';
@@ -207,6 +207,15 @@ export const BarChart = ({
                 scale={xScale}
                 tickValues={tickValues}
                 tickFormat={v => Number(v).toLocaleString()}
+                tickLabelProps={() => ({
+                  style: {
+                    fontFamily: theme.fonts.body,
+                    fontSize: theme.fontSizes['2xs'],
+                    fontWeight: theme.fontWeights.semibold,
+                    fill: theme.colors.text.heading,
+                    textAnchor: 'middle',
+                  },
+                })}
               />
               <GridColumns
                 scale={xScale}

--- a/src/components/visualizations/bar/index.tsx
+++ b/src/components/visualizations/bar/index.tsx
@@ -69,7 +69,7 @@ const getTermColor = (data: ChartDatum[]) =>
 export const BarChart = ({
   width: initialWidth = 400,
   height: initialHeight = 400,
-  margin = { top: 10, right: 20, bottom: 0, left: 0 },
+  margin = { top: 10, right: 40, bottom: 0, left: 0 },
   data,
   onSliceClick,
   isSliceSelected,
@@ -89,7 +89,6 @@ export const BarChart = ({
   const svgWidth = width;
   const svgHeight = height;
   const innerWidth = Math.max(0, width - margin.left - margin.right);
-  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
   // Calculate the usable bar width after accounting for label space.
   const barMaxWidth = Math.max(0, innerWidth - labelStyles.width);
@@ -97,8 +96,7 @@ export const BarChart = ({
   // Axis max value for formatting
   const maxVal = useMemo(() => Math.max(...data.map(d => d.value), 1), [data]);
   const { niceMax, tickValues } = useMemo(() => {
-    // keep your special casing if you like, but this generally works well
-    return makeNiceTicks({ maxValue: maxVal, targetTickCount: 3 });
+    return makeNiceTicks({ maxValue: maxVal });
   }, [maxVal]);
   const xScale = useMemo(() => {
     return applyLogScale
@@ -208,7 +206,7 @@ export const BarChart = ({
                 left={labelStyles.width}
                 scale={xScale}
                 tickValues={tickValues}
-                tickFormat={v => `${Math.round(Number(v)).toLocaleString()}`}
+                tickFormat={v => Number(v).toLocaleString()}
               />
               <GridColumns
                 scale={xScale}

--- a/src/components/visualizations/bar/index.tsx
+++ b/src/components/visualizations/bar/index.tsx
@@ -29,11 +29,10 @@ import { makeNiceTicks } from './helpers';
 
 const barStyles = {
   height: {
-    min: 8,
-    max: 8,
+    // cap the bar height to prevent overly tall bars with few items or in expanded mode
+    max: 10,
     expanded: {
-      min: 8,
-      max: 22,
+      max: 20,
     },
   },
   selected: {
@@ -48,11 +47,17 @@ const barStyles = {
   fill: theme.colors.gray[200],
   fillOpacity: 0.6,
 };
+// label styles are minimal since we're hiding the axis line and ticks, but we need to reserve space for the tick labels
 const labelStyles = {
   width: 100,
   padding: 8,
   horizontalAnchor: 'end',
   verticalAnchor: 'middle',
+} as const;
+
+// axis styles are minimal since we're hiding the axis line and ticks, but we need to reserve space for the tick labels
+const axisStyles = {
+  height: 24,
 } as const;
 
 const getTermColor = (data: ChartDatum[]) =>
@@ -81,8 +86,8 @@ export const BarChart = ({
   });
   const svgRef = React.useRef<SVGSVGElement | null>(null);
 
-  const svgWidth = width + margin.left + margin.right;
-  const svgHeight = height + margin.top + margin.bottom;
+  const svgWidth = width;
+  const svgHeight = height;
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
@@ -108,42 +113,35 @@ export const BarChart = ({
         });
   }, [barMaxWidth, maxVal, niceMax, applyLogScale]);
 
-  // ---- Fit-to-height Y layout ----
+  // Fill the available vertical space, but shrink the chart when bars are few.
   const numBars = Math.max(1, data.length);
-
-  // Use available height to determine bar height and spacing
-  const idealBarHeight =
-    (height - (numBars - 1) * barStyles.padding.y) / numBars;
-
-  // Determine bar height within min/max bounds
-  const barHeightMin = isExpanded
-    ? barStyles.height.expanded.min
-    : barStyles.height.min;
 
   const barHeightMax = isExpanded
     ? barStyles.height.expanded.max
     : barStyles.height.max;
 
-  const barHeight = Math.max(
-    barHeightMin,
-    Math.min(barHeightMax, idealBarHeight),
+  // Natural compact height: just enough to render bars snugly.
+  const compactRowHeight = barHeightMax + 12;
+  const naturalSvgHeight =
+    numBars * compactRowHeight + axisStyles.height + margin.top + margin.bottom;
+  const effectiveSvgHeight = Math.min(svgHeight, naturalSvgHeight);
+  const plotHeight = Math.max(
+    0,
+    effectiveSvgHeight - margin.top - margin.bottom - axisStyles.height,
   );
-
-  // This is how tall the bar “stack” actually is.
-  const contentHeight =
-    numBars * barHeight + (numBars - 1) * barStyles.padding.y;
 
   const yScale = useMemo(
     () =>
       scaleBand({
-        range: [0, contentHeight],
+        range: [0, plotHeight],
         domain: data.map(d => d.term),
         paddingInner: 0,
         paddingOuter: 0,
         round: true,
       }),
-    [contentHeight, data],
+    [plotHeight, data, isExpanded],
   );
+  const barHeight = Math.min(barHeightMax, yScale.bandwidth());
 
   const colorScale = useMemo(() => getTermColor(data), [data]);
 
@@ -185,7 +183,11 @@ export const BarChart = ({
       <Flex ref={parentRef} w='100%' h='100%'>
         <div
           ref={containerRef}
-          style={{ position: 'relative', width: svgWidth, height: svgHeight }}
+          style={{
+            position: 'relative',
+            width: svgWidth,
+            height: effectiveSvgHeight,
+          }}
         >
           {/* Accessible title + description */}
           {/* <VisuallyHidden>
@@ -196,13 +198,13 @@ export const BarChart = ({
             ref={svgRef}
             role='img'
             width={svgWidth}
-            height={svgHeight}
+            height={effectiveSvgHeight}
             // aria-labelledby='summary-stacked-title'
             // aria-describedby='summary-stacked-desc'
           >
             <Group top={margin.top} left={margin.left}>
               <AxisBottom
-                top={contentHeight}
+                top={plotHeight}
                 left={labelStyles.width}
                 scale={xScale}
                 tickValues={tickValues}
@@ -211,7 +213,7 @@ export const BarChart = ({
               <GridColumns
                 scale={xScale}
                 width={innerWidth}
-                height={contentHeight}
+                height={plotHeight}
                 left={labelStyles.width}
                 tickValues={tickValues}
                 stroke='#e0e0e0'
@@ -224,7 +226,8 @@ export const BarChart = ({
                 const barWidth = xScale(value) || 0;
 
                 const rowY = yScale(term) ?? 0;
-                const barY = rowY;
+                const barY =
+                  rowY + Math.max(0, (yScale.bandwidth() - barHeight) / 2);
 
                 const fill = colorScale(id);
                 const isHovered = hoveredId === id;
@@ -338,18 +341,6 @@ export const BarChart = ({
               })}
             </Group>
           </svg>
-          {/* {moreItem.length > 0 && (
-            <Button
-              size='xs'
-              variant='ghost'
-              textDecoration='underline'
-              onClick={() => onSliceClick?.(moreItem[0].id)}
-              colorScheme='blue'
-              color='link.color'
-            >
-              {moreItem[0].label + ` (${moreItem[0].value})`}
-            </Button>
-          )} */}
 
           {/* Tooltip */}
           {tooltipOpen && tooltipData && (

--- a/src/views/search/components/summary/helpers.ts
+++ b/src/views/search/components/summary/helpers.ts
@@ -157,7 +157,8 @@ export const bucketSmallValues = (
     tail,
   };
 };
-
+const capitalizeFirstLetter = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1);
 // Mapping chart types to their respective components and data mappers.
 const mapFacetsToChartData = (
   data: FacetTerm[],
@@ -174,7 +175,7 @@ const mapFacetsToChartData = (
     // Apply transformData if provided
     const transformed = config.transformData
       ? config.transformData({ count: b.count, term: b.term })
-      : { count: b.count, term: b.term, label: b.term };
+      : { count: b.count, term: b.term, label: capitalizeFirstLetter(b.term) };
 
     return {
       id: transformed.term,

--- a/src/views/search/components/summary/hooks/useVisualizationData.tsx
+++ b/src/views/search/components/summary/hooks/useVisualizationData.tsx
@@ -123,9 +123,10 @@ export const useVisualizationData = ({
 
   const formatChartLabel = useCallback(
     (term: string, count: number) => {
-      if (chartType === 'bar') return term;
       if (isHistogramChart) return term.split('-')[0] || term;
-      return `${term} (${count.toLocaleString()})`;
+      const capitalizedTerm = term.charAt(0).toUpperCase() + term.slice(1);
+      if (chartType === 'bar') return capitalizedTerm;
+      return `${capitalizedTerm} (${count.toLocaleString()})`;
     },
     [chartType, isHistogramChart],
   );

--- a/src/views/search/components/summary/hooks/useVisualizationData.tsx
+++ b/src/views/search/components/summary/hooks/useVisualizationData.tsx
@@ -123,10 +123,9 @@ export const useVisualizationData = ({
 
   const formatChartLabel = useCallback(
     (term: string, count: number) => {
+      if (chartType === 'bar') return term;
       if (isHistogramChart) return term.split('-')[0] || term;
-      const capitalizedTerm = term.charAt(0).toUpperCase() + term.slice(1);
-      if (chartType === 'bar') return capitalizedTerm;
-      return `${capitalizedTerm} (${count.toLocaleString()})`;
+      return `${term} (${count.toLocaleString()})`;
     },
     [chartType, isHistogramChart],
   );

--- a/src/views/search/components/summary/index.tsx
+++ b/src/views/search/components/summary/index.tsx
@@ -52,7 +52,14 @@ const SummaryGrid = (props: SummaryGridProps) => {
       <FiltersDisclaimer />
 
       {props.activeVizIds.length > 0 && (
-        <SimpleGrid columns={{ base: 1, md: 2, xl: 3 }} spacing={4} mt={2}>
+        <SimpleGrid
+          templateColumns={{
+            base: 'repeat(auto-fill, minmax(325px, 1fr))',
+            '2xl': 'repeat(3, minmax(325px, 1fr))',
+          }}
+          spacing={4}
+          mt={2}
+        >
           {/* Map over config to render visualizations - only for configs with chart config */}
           {props.configs
             .filter(config => !!config.chart)


### PR DESCRIPTION
This pull request makes several improvements to the bar chart visualization and the summary grid layout. The main focus is on enhancing the appearance and usability of bar charts (including axis ticks, sizing, and label handling), as well as improving the layout of summary visualizations for better responsiveness.
References: https://github.com/NIAID-Data-Ecosystem/niaid-feedback/issues/101#issuecomment-3862049727

**Bar chart improvements:**

* Enhanced the "nice" tick calculation in `makeNiceTicks` by expanding the multipliers and adjusting the logic to produce more human-friendly axis ticks, especially for large numbers. The function now also ensures the minimum tick is 1, not 0, and rounds steps to integers for count data.
* Adjusted bar sizing and chart height calculation to cap bar heights, better fit the chart to the number of bars, and ensure the chart shrinks appropriately when there are few items. This includes new axis and label style constants and improved vertical space usage. 
* Improved tick label formatting and styling on the axis, making them easier to read and consistent with the theme.
* Improved label rendering for bars to handle overflow gracefully with ellipsis, ensuring long labels don't break the layout.
* Cleaned up unused code and removed commented-out code for better maintainability.

**Summary grid and data improvements:**

* Updated the summary grid layout to use a responsive `auto-fill` grid, ensuring visualizations adapt better to different screen sizes and resolutions.


These changes collectively improve the visual quality, usability, and responsiveness of summary visualizations in the application.