### PR TITLE
fix: allow column sorting via arrow interaction

### DIFF
--- a/src/components/popover/hooks/useSelectableList.ts
+++ b/src/components/popover/hooks/useSelectableList.ts
@@ -204,13 +204,11 @@ export const useSelectableList = ({
   const moveUp = useCallback(
     (id: string) => {
       setOrder(prev => {
+        const pinnedRequired = requiredIds.filter(i => prev.includes(i));
         const movable = prev.filter(i => !requiredIds.includes(i));
         const idx = movable.indexOf(id);
         if (idx <= 0) return prev;
-        const next = pinRequired(
-          arrayMove(movable, idx, idx - 1),
-          requiredIds.filter(i => prev.includes(i)),
-        );
+        const next = [...pinnedRequired, ...arrayMove(movable, idx, idx - 1)];
         writeToStorage(storageKeyOrder ?? null, next);
         return next;
       });
@@ -221,13 +219,11 @@ export const useSelectableList = ({
   const moveDown = useCallback(
     (id: string) => {
       setOrder(prev => {
+        const pinnedRequired = requiredIds.filter(i => prev.includes(i));
         const movable = prev.filter(i => !requiredIds.includes(i));
         const idx = movable.indexOf(id);
         if (idx === -1 || idx >= movable.length - 1) return prev;
-        const next = pinRequired(
-          arrayMove(movable, idx, idx + 1),
-          requiredIds.filter(i => prev.includes(i)),
-        );
+        const next = [...pinnedRequired, ...arrayMove(movable, idx, idx + 1)];
         writeToStorage(storageKeyOrder ?? null, next);
         return next;
       });


### PR DESCRIPTION
# Summary

This PR resolves an issue where reordering columns via arrow controls caused the `Identifier` and `Name` fields to be removed from both the column selector and the samples table. The fix ensures these fields remain visible during column reordering.