### PR TITLE
fix(advanced-search): query parsing with parens in source name

### DIFF
--- a/src/components/advanced-search/utils/query-helpers.ts
+++ b/src/components/advanced-search/utils/query-helpers.ts
@@ -106,21 +106,8 @@ export const convertObject2QueryString = (items: TreeItem[]) => {
         if (field) {
           str += `${field}:`;
         }
-        let formattedTerm = querystring ? querystring.trim() : term.trim();
-
-        const containsUnion = unionOptions.some(union =>
-          formattedTerm.includes(union),
-        );
-        // 1. if the term is wrapped in quotes, do nothing.
-        if (
-          formattedTerm.startsWith('"') &&
-          formattedTerm.endsWith('"') &&
-          !containsUnion
-        ) {
-          str += formattedTerm;
-        } else {
-          str += formattedTerm;
-        }
+        const formattedTerm = querystring ? querystring.trim() : term.trim();
+        str += formattedTerm;
 
         // wrap querystring in parenthesis if a field is selected so that the term is applied to the field.
         r += `${union}${str}`;
@@ -150,8 +137,14 @@ export const convertQueryString2Object = (str: string) => {
     var array = [];
     var current = '';
     var depth = 0;
+    let inQuotes = false;
     for (var i = 0; i < string.length; i++) {
-      if (string[i] === '(') {
+      const char = string[i];
+
+      if (char === '"') {
+        inQuotes = !inQuotes;
+        current += char;
+      } else if (!inQuotes && char === '(') {
         depth++;
         if (depth === 1) {
           if (current !== '') {
@@ -161,7 +154,7 @@ export const convertQueryString2Object = (str: string) => {
         } else {
           current += '(';
         }
-      } else if (string[i] === ')') {
+      } else if (!inQuotes && char === ')') {
         depth--;
         if (depth === 0) {
           if (current !== '') {
@@ -172,7 +165,7 @@ export const convertQueryString2Object = (str: string) => {
           current += ')';
         }
       } else {
-        current += string[i];
+        current += char;
       }
     }
     if (current !== '') {

--- a/src/components/advanced-search/utils/validation-checks.ts
+++ b/src/components/advanced-search/utils/validation-checks.ts
@@ -84,21 +84,30 @@ export const checkMissingUnion = (str: string): ValidationConfig => {
   );
 
   let isMissingUnion = false;
+
+  // Tokenize fielded quoted terms as a single token, e.g. field:"Omics Discovery Index (OmicsDI)".
+  const regex = /[a-zA-Z0-9_.]+:"[^"]*"|"[^"]*"|\(|\)|AND|OR|NOT|[^\s()]+/g;
+  const queryWords = str.match(regex) || [];
+
+  const isUnionOperator = (token: string) =>
+    token === 'AND' || token === 'OR' || token === 'NOT';
+
   // if a closed parenthesis is immediately followed by an open parenthesis, then there is no union operator between them
-  if (str.replace(/\s/g, '').includes(')(')) {
+  if (
+    queryWords.some((token, i) => token === ')' && queryWords[i + 1] === '(')
+  ) {
     return { isValid: false, error };
   }
-  var regex = /"([^"]*)"|(\S+)/g;
-  var queryWords = (str.match(regex) || []).map(m => m.replace(regex, '$1$2'));
+
   queryWords.forEach((item, i) => {
     if (item.startsWith('(') && i > 0 && queryWords[i - 1]) {
       const prevWord = queryWords[i - 1];
-      // if previous word ends in a colon or is a union operator, then there is no error. Not the most robust check, but it works for now.
+
+      // If a grouped clause starts after a normal term, a union operator is missing.
       if (
         prevWord.charAt(prevWord.length - 1) !== ':' &&
-        prevWord !== 'AND' &&
-        prevWord !== 'OR' &&
-        prevWord !== 'NOT'
+        prevWord !== '(' &&
+        !isUnionOperator(prevWord)
       ) {
         isMissingUnion = true;
       }
@@ -109,7 +118,7 @@ export const checkMissingUnion = (str: string): ValidationConfig => {
       queryWords[i + 1]
     ) {
       const nextWord = queryWords[i + 1];
-      if (nextWord !== 'AND' && nextWord !== 'OR' && nextWord !== 'NOT') {
+      if (nextWord !== ')' && !isUnionOperator(nextWord)) {
         isMissingUnion = true;
       }
     }


### PR DESCRIPTION
This pull request improves the robustness and accuracy of advanced search query parsing and validation, particularly around handling quoted phrases, parentheses, and union operators. The main focus is on ensuring that quoted terms and complex fielded queries are tokenized and parsed correctly, and that missing union operators are detected more reliably.

Addresses #440 

**Advanced Search Query Parsing Improvements:**

* Updated the `convertQueryString2Object` function to properly handle quoted strings, ensuring that parentheses inside quotes do not affect parsing logic by tracking when the parser is inside quotes. [[1]](diffhunk://#diff-161e2161945204348e896a8f82b71f1555214d89f19445d00e5f726655a28766R140-R147) [[2]](diffhunk://#diff-161e2161945204348e896a8f82b71f1555214d89f19445d00e5f726655a28766L164-R157) [[3]](diffhunk://#diff-161e2161945204348e896a8f82b71f1555214d89f19445d00e5f726655a28766L175-R168)

**Validation Logic Enhancements:**

* Improved the `checkMissingUnion` function to tokenize fielded quoted terms as single tokens (e.g., `field:"Omics Discovery Index (OmicsDI)"`), making union operator checks more accurate for complex queries.
* Enhanced detection of missing union operators by checking for adjacent parentheses and ensuring union operators are present between grouped clauses and terms, using a more robust tokenization and logical check. [[1]](diffhunk://#diff-70f5f3b9985ad7063095b8abf9c30b8b0b656f679b53e4b4b71dc49b450acb26R87-R110) [[2]](diffhunk://#diff-70f5f3b9985ad7063095b8abf9c30b8b0b656f679b53e4b4b71dc49b450acb26L112-R121)

**Code Simplification and Cleanup:**

* Removed redundant logic in `convertObject2QueryString` related to quoted term handling, simplifying the term formatting process.
* Streamlined token handling in the parsing and validation functions for improved readability and maintainability. [[1]](diffhunk://#diff-161e2161945204348e896a8f82b71f1555214d89f19445d00e5f726655a28766L175-R168) [[2]](diffhunk://#diff-70f5f3b9985ad7063095b8abf9c30b8b0b656f679b53e4b4b71dc49b450acb26R87-R110)