### PR TITLE
feat(sample-table): add status column

### DIFF
--- a/src/views/search/components/results-list/components/sample-results-table/index.tsx
+++ b/src/views/search/components/results-list/components/sample-results-table/index.tsx
@@ -23,6 +23,7 @@ const COLUMN_API_SORT_FIELDS: Record<string, string | null> = {
   infectiousAgent: null,
   species: null,
   conditionsOfAccess: 'conditionsOfAccess',
+  creativeWorkStatus: 'creativeWorkStatus',
   variableMeasured: null,
   measurementTechnique: null,
   anatomicalStructure: null,
@@ -120,6 +121,14 @@ export const ALL_SAMPLE_COLUMNS: SampleColumn[] = [
     isSortable: true,
     apiSortField: COLUMN_API_SORT_FIELDS['conditionsOfAccess'],
     props: withWidth('180px'),
+  },
+  {
+    id: 'creativeWorkStatus',
+    title: 'Status',
+    property: 'creativeWorkStatus',
+    isSortable: true,
+    apiSortField: COLUMN_API_SORT_FIELDS['creativeWorkStatus'],
+    props: withWidth('150px'),
   },
   {
     id: 'variableMeasured',

--- a/src/views/search/config/fields.ts
+++ b/src/views/search/config/fields.ts
@@ -55,6 +55,7 @@ export const SAMPLE_FIELDS = [
   'date',
   'description',
   'conditionsOfAccess',
+  'creativeWorkStatus',
   'healthCondition',
   'infectiousAgent',
   'species',


### PR DESCRIPTION
# Summary

This PR adds a **Status** column to the **Samples** table, using values from the `creativeWorkStatus` property.