### PR TITLE
feat(advanced-search-dropdown-menu): hide sample fields in production

### DIFF
--- a/src/components/advanced-search/components/Search/components/FieldSelect/index.tsx
+++ b/src/components/advanced-search/components/Search/components/FieldSelect/index.tsx
@@ -25,6 +25,10 @@ import Fuse from 'fuse.js';
 import { QueryValue } from 'src/components/advanced-search/types';
 import { SchemaDefinition } from 'scripts/generate-schema-definitions/types';
 import ADVANCED_SEARCH from 'configs/advanced-search-fields.json';
+import {
+  SHOULD_HIDE_SAMPLE_FIELDS,
+  HIDDEN_SAMPLE_FIELDS,
+} from 'src/utils/feature-flags';
 
 /****
  * Overlapping or unnecessary fields.
@@ -351,6 +355,7 @@ export const FieldSelectWithContext = () => {
   const schema = Object.values(SCHEMA_DEFINITIONS).filter(
     item => !!item.isAdvancedSearchField,
   );
+
   const fields = [
     {
       name: 'All Fields',
@@ -359,8 +364,16 @@ export const FieldSelectWithContext = () => {
       count: SCHEMA_DEFINITIONS['@type']['count'],
       type: 'text',
     },
-    ...Object.values(schema).filter(item => !!item.isAdvancedSearchField),
+    // Filter out sample-related fields in production until the dataset sample section
+    // is approved for release. The gated dotfields are hardcoded in
+    // HIDDEN_SAMPLE_FIELDS.
+    ...Object.values(schema).filter(
+      item =>
+        !!item.isAdvancedSearchField &&
+        !(SHOULD_HIDE_SAMPLE_FIELDS && HIDDEN_SAMPLE_FIELDS.has(item.dotfield)),
+    ),
   ] as SchemaDefinition[];
+
   return (
     <FieldSelect
       selectedField={queryValue.field}

--- a/src/utils/feature-flags/index.ts
+++ b/src/utils/feature-flags/index.ts
@@ -41,3 +41,30 @@ export const SHOW_CUSTOMIZABLE_FILTERS = !isProd;
 
 // Enable account creation and login features in non-production environments for testing/review. To enable in production, set this flag to `true`.
 export const ENABLE_AUTH = !isProd;
+
+/**
+ * Hide sample-related fields in the advanced search field dropdown in production
+ * builds until approved. To enable these fields in production, set this flag to `false`.
+ */
+export const SHOULD_HIDE_SAMPLE_FIELDS = isProd;
+
+/**
+ * The set of advanced-search field dotfields that are gated behind the
+ * SHOULD_HIDE_SAMPLE_FIELDS flag.
+ */
+export const HIDDEN_SAMPLE_FIELDS = new Set<string>([
+  'sample.aggregateElement.anatomicalStructure.name',
+  'sample.aggregateElement.associatedGenotype',
+  'sample.aggregateElement.associatedPhenotype.name',
+  'sample.aggregateElement.cellType.name',
+  'sample.aggregateElement.developmentalStage.name',
+  'sample.aggregateElement.sampleType.name',
+  'sample.aggregateElement.sex',
+  'sample.anatomicalStructure.name',
+  'sample.associatedGenotype',
+  'sample.associatedPhenotype.name',
+  'sample.cellType.name',
+  'sample.developmentalStage.name',
+  'sample.sampleType.name',
+  'sample.sex',
+]);


### PR DESCRIPTION
# Summary

This PR gates the experimental and population sample fields on the **Advanced Search** page behind a feature flag.