### PR TITLE
fix: safe optional chaining on placeholderData in sources page

### DIFF
--- a/src/pages/sources.tsx
+++ b/src/pages/sources.tsx
@@ -61,7 +61,7 @@ const Sources: NextPage<SourcesProps> = ({ data, error }) => {
   } = useQuery({
     queryKey: ['metadata'],
     queryFn: fetchMetadata,
-    placeholderData: () => data.sourceMetadata.data,
+    placeholderData: () => data?.sourceMetadata?.data,
     select: res => {
       const sources = res.src;
       const sourceDetails = Object.entries(sources).map(([key, source]) => {


### PR DESCRIPTION
# Summary

This PR prevents build crash on `/sources` page when metadata fetch fails. 

During static build, if `fetchMetadata()` fails,` getStaticProps` returns props without a data object. This caused `placeholderData `in the `useQuery` hook to crash trying to read sourceMetadata from undefined.

