### PR TITLE
feat(sample-and-data-collection-tables): set number of rows to 50

### DIFF
--- a/src/views/search/components/search-results-tabs-controller/index.tsx
+++ b/src/views/search/components/search-results-tabs-controller/index.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../hooks/useBioSampleAggregation';
 import { queryFilterObject2String } from '../filters/utils/query-string';
 import { fetchSearchResults, Params } from 'src/utils/api';
-import { defaultQuery } from '../../config/defaultQuery';
+import { defaultQuery, getDefaultSizeForTab } from '../../config/defaultQuery';
 import { SAMPLE_FIELDS, DATA_COLLECTION_FIELDS } from '../../config/fields';
 
 const CAROUSEL_RESULTS_FIELDS = [
@@ -145,7 +145,7 @@ export const SearchResultsController = ({
       facets: '',
       fields: SAMPLE_FIELDS,
       sort: defaultQuery.sort,
-      size: `${defaultQuery.size}`,
+      size: `${getDefaultSizeForTab('s')}`,
       from: '0',
       use_metadata_score: 'false',
       use_ai_search: queryParams.use_ai_search ?? 'false',
@@ -174,7 +174,7 @@ export const SearchResultsController = ({
       facets: '',
       fields: DATA_COLLECTION_FIELDS,
       sort: defaultQuery.sort,
-      size: `${defaultQuery.size}`,
+      size: `${getDefaultSizeForTab('dc')}`,
       from: '0',
       use_metadata_score: 'false',
       use_ai_search: queryParams.use_ai_search ?? 'false',

--- a/src/views/search/config/defaultQuery.ts
+++ b/src/views/search/config/defaultQuery.ts
@@ -78,6 +78,16 @@ export const defaultQuery: DefaultSearchQueryParams = {
   sort: SORT_OPTIONS[0].value,
 };
 
+// Tabs that should default to a larger page size. Any tab not listed here
+// falls back to defaultQuery.size (10).
+export const DEFAULT_SIZE_BY_TAB: Record<string, number> = {
+  s: 50, // Samples
+  dc: 50, // Data Collections
+};
+
+export const getDefaultSizeForTab = (tabId: string): number =>
+  DEFAULT_SIZE_BY_TAB[tabId] ?? defaultQuery.size;
+
 export const defaultSelectedFilters = {
   date: getDefaultDateFilter(),
 };

--- a/src/views/search/context/pagination-context.tsx
+++ b/src/views/search/context/pagination-context.tsx
@@ -7,7 +7,7 @@ import {
   ReactNode,
 } from 'react';
 import { useRouter } from 'next/router';
-import { defaultQuery } from '../config/defaultQuery';
+import { defaultQuery, getDefaultSizeForTab } from '../config/defaultQuery';
 import { DEFAULT_TAB_ID, useSearchTabsContext } from './search-tabs-context';
 
 export type PaginationState = {
@@ -45,7 +45,7 @@ export const PaginationProvider = ({ children }: { children: ReactNode }) => {
         tab.id,
         {
           from: defaultQuery.from,
-          size: defaultQuery.size,
+          size: getDefaultSizeForTab(tab.id),
           sort: defaultQuery.sort,
         },
       ]),
@@ -67,7 +67,7 @@ export const PaginationProvider = ({ children }: { children: ReactNode }) => {
         [urlTab]: {
           ...prev[urlTab],
           from: urlFrom,
-          size: urlSize || defaultQuery.size,
+          size: urlSize || getDefaultSizeForTab(urlTab),
           sort: urlSort || defaultQuery.sort,
         },
       }));
@@ -79,7 +79,7 @@ export const PaginationProvider = ({ children }: { children: ReactNode }) => {
     (tabId: string) =>
       paginationByTab[tabId] || {
         from: defaultQuery.from,
-        size: defaultQuery.size,
+        size: getDefaultSizeForTab(tabId),
         sort: defaultQuery.sort,
       },
     [paginationByTab],


### PR DESCRIPTION
# Summary

This PR increases the default number of rows displayed in the `Sample `and `DataCollection` tables on the **Search Results page** to 50.