### PR TITLE
feat(repository-matcher): address UI feedback NIAID-Data-Ecosystem/niaid-feedback#276 

### DIFF
--- a/configs/site.config.json
+++ b/configs/site.config.json
@@ -75,12 +75,12 @@
     "/repository-matcher": {
       "seo": {
         "title": "Repository Matcher",
-        "description": "Find a suitable repository to deposit your data using the NIAID Data Ecosystem Discovery Portal.",
+        "description": "Find a suitable repository that accepts research data deposits using the NIAID Data Ecosystem Discovery Portal.",
         "keywords": []
       },
       "nav": {
-        "label": "Respository Matcher",
-        "description": "Find a suitable repository to deposit your data"
+        "label": "Repository Matcher",
+        "description": "Find a suitable repository that accepts research data deposits."
       }
     },
     "/advanced-search": {

--- a/src/components/table/components/cell.tsx
+++ b/src/components/table/components/cell.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   TextProps,
 } from '@chakra-ui/react';
+import Tooltip from 'src/components/tooltip';
 import { TableSortToggle } from './sort-toggle';
 
 // Label component - displays text in a specific style.
@@ -82,6 +83,8 @@ interface ThProps extends CellProps {
   colorScheme?: ButtonProps['colorScheme'];
   isSelected?: boolean;
   isSortable?: boolean;
+  /** Optional descriptive text. */
+  tooltip?: string;
   tableSortToggleProps?: {
     isSelected: boolean;
     sortBy: 'ASC' | 'DESC';
@@ -96,6 +99,7 @@ export const Th = React.memo(
     isSelected,
     label,
     isSortable,
+    tooltip,
     tableSortToggleProps,
     ...props
   }: ThProps) => {
@@ -123,7 +127,15 @@ export const Th = React.memo(
         whiteSpace='pre-wrap'
         {...props}
       >
-        {label && <Label>{label}</Label>}
+        {label && (
+          <Flex alignItems='center' gap={1}>
+            <Tooltip label={tooltip} hasArrow>
+              <Box as='span' display='inline-flex' color='gray.600'>
+                <Label>{label}</Label>
+              </Box>
+            </Tooltip>
+          </Flex>
+        )}
         {isSortable && tableSortToggleProps && (
           <Box
             my={1}

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -27,6 +27,11 @@ export interface Column {
   title: string;
   property: string;
   isSortable?: boolean;
+  /**
+   * Optional descriptive text shown on a tooltip column header label.
+   * Omit to render the header without a tooltip.
+   */
+  tooltip?: string;
   props?: any;
   renderCell?: (props: {
     column: Column;
@@ -606,6 +611,7 @@ export const Table: React.FC<TableProps<any>> = ({
             key={`table-col-th-${column.property}`}
             as={cellAs}
             label={column.title}
+            tooltip={column.tooltip}
             isSelected={isSelected}
             borderBottomColor={`${colorScheme}.200`}
             isSortable={column.isSortable}

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -116,6 +116,7 @@ const RepositoryMatcher: NextPage = () => {
         title: col.label,
         property: col.id,
         isSortable: col.columns?.isSortable,
+        tooltip: col.info?.tooltip || '',
         props: col.columns?.style,
       }));
   }, [visibleColumnIds, orderedColumnIds]);

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -320,55 +320,7 @@ const RepositoryMatcher: NextPage = () => {
               isLoading={isLoading}
             />
           </Box>
-          {/* <!-- Filter Tags--> */}
-          {filterTags.length > 0 && (
-            <Text
-              display={{ base: 'block', md: 'none' }}
-              fontSize='sm'
-              fontWeight='semibold'
-              mb={1}
-            >
-              Active Filters:
-            </Text>
-          )}
-          <Stack
-            direction='row'
-            spacing={2}
-            flex={1}
-            flexWrap='wrap'
-            minW={{ base: 0, md: '300px' }}
-          >
-            {filterTags.length > 0 && (
-              <Tag
-                key='clear'
-                size='lg'
-                variant='outline'
-                borderRadius='full'
-                colorScheme='primary'
-                borderColor='primary.100'
-              >
-                <TagLabel>Clear all</TagLabel>
-                <TagCloseButton onClick={() => setSelectedFilters({})} />
-              </Tag>
-            )}
-            {filterTags.map(filter => {
-              const { property, value } = filter;
-              return (
-                <Tag
-                  key={property + '-' + value}
-                  size='lg'
-                  variant='subtle'
-                  borderRadius='full'
-                  colorScheme='primary'
-                >
-                  <TagLabel fontWeight='medium'>{value}</TagLabel>
-                  <TagCloseButton
-                    onClick={() => removeSingleFilter(property, value)}
-                  />
-                </Tag>
-              );
-            })}
-          </Stack>
+
           <Flex
             w='100%'
             py={2}
@@ -417,6 +369,56 @@ const RepositoryMatcher: NextPage = () => {
               </Flex>
             }
           />
+          {/* <!-- Filter Tags--> */}
+          {filterTags.length > 0 && (
+            <Text
+              display={{ base: 'block', md: 'none' }}
+              fontSize='sm'
+              fontWeight='semibold'
+              mt={4}
+            >
+              Active Filters:
+            </Text>
+          )}
+          <Stack
+            direction='row'
+            spacing={2}
+            flex={1}
+            flexWrap='wrap'
+            minW={{ base: 0, md: '300px' }}
+            my={4}
+          >
+            {filterTags.length > 0 && (
+              <Tag
+                key='clear'
+                size='lg'
+                variant='outline'
+                borderRadius='full'
+                colorScheme='primary'
+                borderColor='primary.100'
+              >
+                <TagLabel>Clear all</TagLabel>
+                <TagCloseButton onClick={() => setSelectedFilters({})} />
+              </Tag>
+            )}
+            {filterTags.map(filter => {
+              const { property, value } = filter;
+              return (
+                <Tag
+                  key={property + '-' + value}
+                  size='lg'
+                  variant='subtle'
+                  borderRadius='full'
+                  colorScheme='primary'
+                >
+                  <TagLabel fontWeight='medium'>{value}</TagLabel>
+                  <TagCloseButton
+                    onClick={() => removeSingleFilter(property, value)}
+                  />
+                </Tag>
+              );
+            })}
+          </Stack>
           {/* Information and definitions section */}
           <TableDefinitions columns={COLUMNS_WITH_DEFINITIONS} />
         </Box>

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -321,55 +321,6 @@ const RepositoryMatcher: NextPage = () => {
               isLoading={isLoading}
             />
           </Box>
-
-          <Flex
-            w='100%'
-            py={2}
-            justifyContent='space-between'
-            alignItems='flex-end'
-          >
-            <Text fontSize='sm' fontWeight='semibold' lineHeight='normal'>
-              {sortedData?.length ?? 0} results
-            </Text>
-            <VStack alignItems='flex-end'>
-              <Checkbox
-                isChecked={stickyFirstColumn}
-                onChange={e => setStickyFirstColumn(e.target.checked)}
-                colorScheme='primary'
-              >
-                <Text fontSize='xs'>Pin first column</Text>
-              </Checkbox>
-              <CustomizeColumnsPopover
-                onVisibleColumnsChange={handleVisibleColumnsChange}
-                onColumnOrderChange={handleColumnOrderChange}
-              />
-            </VStack>
-          </Flex>
-          <Table
-            ariaLabel='Repository matcher table'
-            caption='Repositories and resource catalogs available for data deposit'
-            columns={tableColumns}
-            data={tableData as any}
-            isLoading={isLoading}
-            hasPagination={false}
-            stickyHeader
-            stickyFirstColumn={stickyFirstColumn}
-            virtualized
-            tableContainerProps={TABLE_CONTAINER_PROPS}
-            getTableRowProps={getTableRowProps}
-            controlledSortProperty={sortProperty}
-            controlledSortAsc={sortAsc}
-            onControlledSort={handleSort}
-            getCells={getCells}
-            emptyState={
-              <Flex direction='column' align='center' py={10}>
-                <Text fontWeight='bold'>No repositories match</Text>
-                <Text color='gray.600'>
-                  Try clearing some filters or broadening your search.
-                </Text>
-              </Flex>
-            }
-          />
           {/* <!-- Filter Tags--> */}
           {filterTags.length > 0 && (
             <Text
@@ -420,6 +371,55 @@ const RepositoryMatcher: NextPage = () => {
               );
             })}
           </Stack>
+          <Flex
+            w='100%'
+            py={2}
+            justifyContent='space-between'
+            alignItems='flex-end'
+          >
+            <Text fontSize='sm' fontWeight='semibold' lineHeight='normal'>
+              {sortedData?.length ?? 0} results
+            </Text>
+            <VStack alignItems='flex-end'>
+              <Checkbox
+                isChecked={stickyFirstColumn}
+                onChange={e => setStickyFirstColumn(e.target.checked)}
+                colorScheme='primary'
+              >
+                <Text fontSize='xs'>Pin first column</Text>
+              </Checkbox>
+              <CustomizeColumnsPopover
+                onVisibleColumnsChange={handleVisibleColumnsChange}
+                onColumnOrderChange={handleColumnOrderChange}
+              />
+            </VStack>
+          </Flex>
+          <Table
+            ariaLabel='Repository matcher table'
+            caption='Repositories and resource catalogs available for data deposit'
+            columns={tableColumns}
+            data={tableData as any}
+            isLoading={isLoading}
+            hasPagination={false}
+            stickyHeader
+            stickyFirstColumn={stickyFirstColumn}
+            virtualized
+            tableContainerProps={TABLE_CONTAINER_PROPS}
+            getTableRowProps={getTableRowProps}
+            controlledSortProperty={sortProperty}
+            controlledSortAsc={sortAsc}
+            onControlledSort={handleSort}
+            getCells={getCells}
+            emptyState={
+              <Flex direction='column' align='center' py={10}>
+                <Text fontWeight='bold'>No repositories match</Text>
+                <Text color='gray.600'>
+                  Try clearing some filters or broadening your search.
+                </Text>
+              </Flex>
+            }
+          />
+
           {/* Information and definitions section */}
           <TableDefinitions columns={COLUMNS_WITH_DEFINITIONS} />
         </Box>

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -116,7 +116,7 @@ const RepositoryMatcher: NextPage = () => {
         title: col.label,
         property: col.id,
         isSortable: col.columns?.isSortable,
-        tooltip: col.info?.tooltip || '',
+        tooltip: col.info?.description || '',
         props: col.columns?.style,
       }));
   }, [visibleColumnIds, orderedColumnIds]);

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -34,7 +34,7 @@ import {
 } from 'src/views/repository-matcher/hooks/useRepositoryMatcherFilters';
 import { useSearchedData } from 'src/views/repository-matcher/hooks/useSearchedData';
 import { REPOSITORY_MATCHER_COLUMNS } from 'src/views/repository-matcher/table-config';
-import { TableDefinitions } from 'src/views/repository-matcher/components/TableDefinitions';
+import { DataDictionary } from 'src/views/repository-matcher/components/DataDictionary';
 
 const TABLE_CONTAINER_PROPS = {
   overflowX: 'auto' as const,
@@ -421,7 +421,7 @@ const RepositoryMatcher: NextPage = () => {
           />
 
           {/* Information and definitions section */}
-          <TableDefinitions columns={COLUMNS_WITH_DEFINITIONS} />
+          <DataDictionary columns={COLUMNS_WITH_DEFINITIONS} />
         </Box>
       </Flex>
     </PageContainer>

--- a/src/pages/repository-matcher.tsx
+++ b/src/pages/repository-matcher.tsx
@@ -256,8 +256,8 @@ const RepositoryMatcher: NextPage = () => {
           Repository Matcher
         </Heading>
         <Text fontSize='md' lineHeight='short'>
-          Find a suitable repository to deposit your data. Filter by type,
-          research domain, accepted data, and more.
+          Find a suitable repository that accepts research data deposits. Filter
+          by research domain, repository type, and other criteria.
         </Text>
       </Flex>
       <Divider />

--- a/src/views/repository-matcher/components/DataDictionary.tsx
+++ b/src/views/repository-matcher/components/DataDictionary.tsx
@@ -2,17 +2,13 @@ import React from 'react';
 import { Box, Heading, Text, VStack } from '@chakra-ui/react';
 import { RepositoryMatcherColumn } from '../types';
 
-interface TableDefinitionsProps {
+interface DataDictionaryProps {
   columns: RepositoryMatcherColumn[];
 }
 
-export const TableDefinitions: React.FC<TableDefinitionsProps> = ({
-  columns,
-}) => {
+export const DataDictionary: React.FC<DataDictionaryProps> = ({ columns }) => {
   return (
-    <VStack
-      align='start'
-      spacing={2}
+    <Box
       my={6}
       fontSize='sm'
       bg='#fff'
@@ -35,15 +31,16 @@ export const TableDefinitions: React.FC<TableDefinitionsProps> = ({
           if (!info) return null;
           const { description, terms } = info;
           return (
-            <VStack
-              key={label}
-              align='start'
-              spacing={2}
-              lineHeight='tall'
-              width='100%'
-              pb={4}
-            >
-              <Box bg='niaid.50' p={2} px={4} width='100%'>
+            <Box key={label} lineHeight='tall' width='100%'>
+              <Box
+                bg='niaid.50'
+                borderTop='1px solid'
+                borderBottom='1px solid'
+                borderColor='niaid.100'
+                p={2}
+                px={4}
+                width='100%'
+              >
                 {label && (
                   <Text
                     fontWeight='semibold'
@@ -53,23 +50,23 @@ export const TableDefinitions: React.FC<TableDefinitionsProps> = ({
                     {label}
                   </Text>
                 )}
-                {description && (
-                  <Text color='gray.800' mb={2}>
-                    {description}
-                  </Text>
-                )}
+                {description && <Text color='gray.800'>{description}</Text>}
               </Box>
-              {terms?.map((term, i) => (
-                <Text key={i} ml={6} fontWeight='semibold'>
-                  {term.label}:{' '}
-                  <Text as='span' fontWeight='normal'>
-                    {term.description}
-                  </Text>
-                </Text>
-              ))}
-            </VStack>
+              {terms && (
+                <VStack mx={6} my={4} alignItems='flex-start'>
+                  {terms?.map(term => (
+                    <Box key={term.label}>
+                      <Text fontWeight='semibold'>{term.label}</Text>
+                      <Text as='span' fontWeight='normal'>
+                        {term.description}
+                      </Text>
+                    </Box>
+                  ))}
+                </VStack>
+              )}
+            </Box>
           );
         })}
-    </VStack>
+    </Box>
   );
 };

--- a/src/views/repository-matcher/components/DataDictionary.tsx
+++ b/src/views/repository-matcher/components/DataDictionary.tsx
@@ -19,10 +19,10 @@ export const DataDictionary: React.FC<DataDictionaryProps> = ({ columns }) => {
     >
       <VStack p={4} alignItems='flex-start'>
         <Heading as='h2' fontSize='lg'>
-          Data Dictionary
+          Table Dictionary
         </Heading>
         <Text lineHeight='short'>
-          [Descriptive text about the data dictionary]
+          Definitions of fields and values used in the Repository Matcher
         </Text>
       </VStack>
       {columns

--- a/src/views/repository-matcher/components/Filters.tsx
+++ b/src/views/repository-matcher/components/Filters.tsx
@@ -43,7 +43,7 @@ const toFilterConfig = (col: RepositoryMatcherColumn<any>): FilterConfig => ({
   name: col.label,
   property: col.id,
   category: 'Dataset',
-  description: col.info?.filterDescription ?? '',
+  description: col.info?.description ?? '',
   queryType: 'facet',
   groupBy: col.filter?.groupBy,
 });

--- a/src/views/repository-matcher/components/TableCells.tsx
+++ b/src/views/repository-matcher/components/TableCells.tsx
@@ -47,7 +47,7 @@ export const DefinedTermTagList = ({
         <TagCell
           key={i}
           value={v?.name || ''}
-          url={v?.url || undefined}
+          // url={v?.url || undefined}
           noOfLines={1}
           isLoading={isLoading}
         />
@@ -78,12 +78,29 @@ export const TagCell = ({
   noOfLines?: number;
   isLoading?: boolean;
 }) => {
+  const [isTruncated, setIsTruncated] = useState(false);
+  const labelRef = useRef<HTMLSpanElement>(null);
+
+  const label = value || '';
+
+  // Only show the tooltip when the label is actually clamped/overflowing.
+  useLayoutEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    const el = labelRef.current;
+    if (el) {
+      setIsTruncated(
+        el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth,
+      );
+    }
+  }, [isLoading, label, noOfLines]);
+
   if (isLoading) {
     return <Skeleton isLoaded={false} width='80px' height='20px' />;
   }
-  const label = value || '';
   return (
-    <Tooltip label={label} isDisabled={!value} hasArrow>
+    <Tooltip label={label} isDisabled={!value || !isTruncated} hasArrow>
       <Box>
         {url ? (
           <TagWithUrl href={url} bg='page.alt'>
@@ -91,7 +108,7 @@ export const TagCell = ({
           </TagWithUrl>
         ) : (
           <Tag variant='subtle' noOfLines={noOfLines} bg='page.alt'>
-            <TagLabel>{label}</TagLabel>
+            <TagLabel ref={labelRef}>{label}</TagLabel>
           </Tag>
         )}
       </Box>

--- a/src/views/repository-matcher/components/TableDefinitions.tsx
+++ b/src/views/repository-matcher/components/TableDefinitions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Text, VStack } from '@chakra-ui/react';
+import { Box, Heading, Text, VStack } from '@chakra-ui/react';
 import { RepositoryMatcherColumn } from '../types';
 
 interface TableDefinitionsProps {
@@ -12,43 +12,64 @@ export const TableDefinitions: React.FC<TableDefinitionsProps> = ({
   return (
     <VStack
       align='start'
-      spacing={4}
+      spacing={2}
       my={6}
       fontSize='sm'
       bg='#fff'
       borderRadius='semi'
       border='1px solid'
       borderColor='gray.100'
-      p={4}
+      overflow='hidden'
     >
-      {columns.map(({ label, info }) => {
-        if (!info) return null;
-        const { description, terms } = info;
-        return (
-          <VStack key={label} align='start' spacing={2} lineHeight='short'>
-            <Box>
-              {label && (
-                <Text fontWeight='semibold' color='text.heading' fontSize='md'>
-                  {label}
+      <VStack p={4} alignItems='flex-start'>
+        <Heading as='h2' fontSize='lg'>
+          Data Dictionary
+        </Heading>
+        <Text lineHeight='short'>
+          [Descriptive text about the data dictionary]
+        </Text>
+      </VStack>
+      {columns
+        .sort((a, b) => a.label.localeCompare(b.label))
+        .map(({ label, info }) => {
+          if (!info) return null;
+          const { description, terms } = info;
+          return (
+            <VStack
+              key={label}
+              align='start'
+              spacing={2}
+              lineHeight='tall'
+              width='100%'
+              pb={4}
+            >
+              <Box bg='niaid.50' p={2} px={4} width='100%'>
+                {label && (
+                  <Text
+                    fontWeight='semibold'
+                    color='text.heading'
+                    fontSize='md'
+                  >
+                    {label}
+                  </Text>
+                )}
+                {description && (
+                  <Text color='gray.800' mb={2}>
+                    {description}
+                  </Text>
+                )}
+              </Box>
+              {terms?.map((term, i) => (
+                <Text key={i} ml={6} fontWeight='semibold'>
+                  {term.label}:{' '}
+                  <Text as='span' fontWeight='normal'>
+                    {term.description}
+                  </Text>
                 </Text>
-              )}
-              {description && (
-                <Text color='gray.800' mb={2}>
-                  {description}
-                </Text>
-              )}
-            </Box>
-            {terms?.map((term, i) => (
-              <Text key={i} ml={2} fontWeight='semibold'>
-                {term.label}:{' '}
-                <Text as='span' fontWeight='normal'>
-                  {term.description}
-                </Text>
-              </Text>
-            ))}
-          </VStack>
-        );
-      })}
+              ))}
+            </VStack>
+          );
+        })}
     </VStack>
   );
 };

--- a/src/views/repository-matcher/hooks/useRepositoryMatcherData.ts
+++ b/src/views/repository-matcher/hooks/useRepositoryMatcherData.ts
@@ -56,8 +56,15 @@ export const useRepositoryMatcherData = (fields: string[] = ['@type']) => {
     combined
       .filter(item => {
         // Exclude items that have creativeWorkStatus of 'Retired' or 'Not Accepting Data'. If not specified, include all items.
-        const status = item?.creativeWorkStatus;
-        return status === 'Accepting Data';
+        const statusIsAcceptingData =
+          item?.creativeWorkStatus === 'Accepting Data';
+
+        // Exclude items with type "Data Repository" or "Sample Repository"
+        const isDataOrSampleRepo =
+          item['type'].includes('Data Repository') ||
+          item['type'].includes('Sample Repository');
+
+        return statusIsAcceptingData && !isDataOrSampleRepo;
       })
       .forEach((item, idx) => {
         const id = item._id || `__no-id-${idx}`;

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -360,7 +360,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
   // },
   {
     id: 'species',
-    label: getMetadataName('species') || '',
+    label: 'Host Species',
     fields: ['species'],
     columns: { isSortable: false, isDefault: true },
     transform: item => {

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -139,7 +139,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       description:
-        'The resource type affects how records from that resource are ingested into the Discovery Portal.',
+        'Type is a Portal-specific classification that indicates how repository content is organized and displayed within the Portal.',
       filterDescription: getMetadataDescription('type') || '',
       terms: [
         {

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -141,14 +141,14 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       tooltip: getMetadataDescription('genre') || '',
       terms: [
         {
-          label: 'IID',
-          description:
-            'A resource specifically designed for Infectious and/or Immune-Mediated Disease content',
-        },
-        {
           label: 'Generalist',
           description:
             'A resource not specifically designed for Infectious and/or Immune-Mediated Disease content',
+        },
+        {
+          label: 'IID',
+          description:
+            'A resource specifically designed for Infectious and/or Immune-Mediated Disease content',
         },
       ],
     },
@@ -193,22 +193,22 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       tooltip: getMetadataDescription('conditionsOfAccess') || '',
       terms: [
         {
-          label: 'Open Access',
-          description: 'The data in the repository is freely available',
-        },
-        {
-          label: 'Varied Access',
-          description:
-            'The repository contains data that varies at the record level',
-        },
-        {
           label: 'Controlled Access',
           description:
             'The repository may include restrictions such as for access or use',
         },
         {
+          label: 'Open Access',
+          description: 'The data in the repository is freely available',
+        },
+        {
           label: 'Registered Access',
           description: 'The repository requires registration to access',
+        },
+        {
+          label: 'Varied Access',
+          description:
+            'The repository contains data that varies at the record level',
         },
       ],
     },
@@ -241,6 +241,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         value?.map(v => v.name).filter((name): name is string => !!name) ?? [],
     },
     info: {
+      description: getMetadataDescription('healthCondition') || '',
       filterDescription: getMetadataDescription('healthCondition') || '',
       tooltip: getMetadataDescription('healthCondition') || '',
     },
@@ -273,6 +274,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         value?.map(v => v.name).filter((name): name is string => !!name) ?? [],
     },
     info: {
+      description: getMetadataDescription('infectiousAgent') || '',
       filterDescription: getMetadataDescription('infectiousAgent') || '',
       tooltip: getMetadataDescription('infectiousAgent') || '',
     },
@@ -388,6 +390,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         value?.map(v => v.name).filter((name): name is string => !!name) ?? [],
     },
     info: {
+      description: getMetadataDescription('species') || '',
       filterDescription: getMetadataDescription('species') || '',
       tooltip: getMetadataDescription('species') || '',
     },
@@ -420,6 +423,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         value?.map(v => v.name).filter((name): name is string => !!name) ?? [],
     },
     info: {
+      description: getMetadataDescription('measurementTechnique') || '',
       filterDescription: getMetadataDescription('measurementTechnique') || '',
       tooltip: getMetadataDescription('measurementTechnique') || '',
     },
@@ -457,6 +461,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         value?.map(v => v.name).filter((name): name is string => !!name) ?? [],
     },
     info: {
+      description: getMetadataDescription('topicCategory') || '',
       filterDescription: getMetadataDescription('topicCategory') || '',
       tooltip: getMetadataDescription('topicCategory') || '',
     },
@@ -534,6 +539,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       return formatted;
     },
     info: {
+      description: getMetadataDescription('temporalCoverage') || '',
       tooltip: getMetadataDescription('temporalCoverage') || '',
     },
   },
@@ -563,6 +569,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
     },
     info: {
+      description: getMetadataDescription('license') || '',
       tooltip: getMetadataDescription('license') || '',
     },
   },
@@ -605,25 +612,25 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
             'A repository which holds Dataset records. Dataset metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
         },
         {
-          label: 'Sample Repository',
-          description:
-            'A repository which holds biological specimen or sample records. Metadata records about samples are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
-        },
-        {
-          label: 'Computational Tool Repository',
-          description:
-            'A repository which holds Computational Tool records. Tool metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
-        },
-        {
-          label: 'Data Repository',
-          description:
-            'A repository which holds other types of records. Records of a searchable type are aggregated from the original source and used to create Data Collection records in the Discovery Portal. Multiple records submitted to a Data Repository may end up as a single Data Collection record in the Discovery Portal.',
-        },
-        {
           label: 'Resource Catalog',
           description:
             ' A manually curated record about the repository/resource/portal etc. itself. Repositories displayed only as Resource Catalogs in the Discovery Portal are not sources of record ingest at this time.',
         },
+        // {
+        //   label: 'Computational Tool Repository',
+        //   description:
+        //   'A repository which holds Computational Tool records. Tool metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
+        // },
+        // {
+        //   label: 'Sample Repository',
+        //   description:
+        //     'A repository which holds biological specimen or sample records. Metadata records about samples are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
+        // },
+        // {
+        //   label: 'Data Repository',
+        //   description:
+        //     'A repository which holds other types of records. Records of a searchable type are aggregated from the original source and used to create Data Collection records in the Discovery Portal. Multiple records submitted to a Data Repository may end up as a single Data Collection record in the Discovery Portal.',
+        // },
       ],
     },
   },

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -138,6 +138,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     info: {
       description: 'Categorical information about the content of a resource.',
       filterDescription: getMetadataDescription('genre') || '',
+      tooltip: getMetadataDescription('genre') || '',
       terms: [
         {
           label: 'IID',
@@ -189,6 +190,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       description:
         'Access-level definitions Options include open (freely available), restricted (may include restrictions such as on use), closed (requires registration to access), or embargoed (unpublished).',
       filterDescription: getMetadataDescription('conditionsOfAccess') || '',
+      tooltip: getMetadataDescription('conditionsOfAccess') || '',
       terms: [
         {
           label: 'Open Access',
@@ -240,6 +242,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       filterDescription: getMetadataDescription('healthCondition') || '',
+      tooltip: getMetadataDescription('healthCondition') || '',
     },
   },
   {
@@ -271,6 +274,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       filterDescription: getMetadataDescription('infectiousAgent') || '',
+      tooltip: getMetadataDescription('infectiousAgent') || '',
     },
   },
   // {
@@ -385,6 +389,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       filterDescription: getMetadataDescription('species') || '',
+      tooltip: getMetadataDescription('species') || '',
     },
   },
   {
@@ -416,6 +421,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       filterDescription: getMetadataDescription('measurementTechnique') || '',
+      tooltip: getMetadataDescription('measurementTechnique') || '',
     },
   },
   {
@@ -452,6 +458,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       filterDescription: getMetadataDescription('topicCategory') || '',
+      tooltip: getMetadataDescription('topicCategory') || '',
     },
   },
   // {
@@ -526,6 +533,9 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
 
       return formatted;
     },
+    info: {
+      tooltip: getMetadataDescription('temporalCoverage') || '',
+    },
   },
   {
     id: 'license',
@@ -551,6 +561,9 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
         );
       }
       return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
+    },
+    info: {
+      tooltip: getMetadataDescription('license') || '',
     },
   },
   {
@@ -584,6 +597,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       description:
         'Type is a Portal-specific classification that indicates how repository content is organized and displayed within the Portal.',
       filterDescription: getMetadataDescription('type') || '',
+      tooltip: getMetadataDescription('type') || '',
       terms: [
         {
           label: 'Dataset Repository',

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -188,7 +188,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       description:
-        'Access-level definitions Options include open (freely available), restricted (may include restrictions such as on use), closed (requires registration to access), or embargoed (unpublished).',
+        'Access-level definitions Options include open (freely available), controlled (may include restrictions such as on use), or registered (requires registration to access).',
       filterDescription: getMetadataDescription('conditionsOfAccess') || '',
       tooltip: getMetadataDescription('conditionsOfAccess') || '',
       terms: [
@@ -202,12 +202,12 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
             'The repository contains data that varies at the record level',
         },
         {
-          label: 'Restricted Access',
+          label: 'Controlled Access',
           description:
             'The repository may include restrictions such as for access or use',
         },
         {
-          label: 'Closed Access',
+          label: 'Registered Access',
           description: 'The repository requires registration to access',
         },
       ],

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -96,80 +96,20 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       );
     },
   },
-  {
-    id: 'abstract',
-    label: getMetadataName('abstract') || '',
-    fields: ['abstract'],
-    columns: { isSortable: true, isDefault: false },
-    transform: (item): RepositoryMatcherItem['abstract'] => item.abstract || '',
-    component: ({
-      value,
-      isLoading,
-    }: {
-      value: RepositoryMatcherItem['abstract'];
-      isLoading?: boolean;
-    }) => <TextCell value={value || ''} isLoading={isLoading} noOfLines={3} />,
-  },
-  {
-    id: 'type',
-    label: getMetadataName('type') || '',
-    fields: ['@type', 'collectionType', 'type'],
-    columns: {
-      isSortable: true,
-      isDefault: true,
-      style: { maxWidth: '180px', minWidth: '180px' },
-    },
-    transform: (item): string[] => itemTypes(item),
-    getSortValue: (value: string[]) => (value[0] || '').toLowerCase(),
-    component: ({
-      value,
-      isLoading,
-    }: {
-      value: string[];
-      isLoading?: boolean;
-    }) => (
-      <TextCell
-        value={value && value.length ? value.join(', ') : ''}
-        isLoading={isLoading}
-        fontWeight='semibold'
-      />
-    ),
-    filter: {
-      getFilterValues: (value: string[]) => value ?? [],
-    },
-    info: {
-      description:
-        'Type is a Portal-specific classification that indicates how repository content is organized and displayed within the Portal.',
-      filterDescription: getMetadataDescription('type') || '',
-      terms: [
-        {
-          label: 'Dataset Repository',
-          description:
-            'A repository which holds Dataset records. Dataset metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
-        },
-        {
-          label: 'Sample Repository',
-          description:
-            'A repository which holds biological specimen or sample records. Metadata records about samples are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
-        },
-        {
-          label: 'Computational Tool Repository',
-          description:
-            'A repository which holds Computational Tool records. Tool metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
-        },
-        {
-          label: 'Data Repository',
-          description:
-            'A repository which holds other types of records. Records of a searchable type are aggregated from the original source and used to create Data Collection records in the Discovery Portal. Multiple records submitted to a Data Repository may end up as a single Data Collection record in the Discovery Portal.',
-        },
-        {
-          label: 'Resource Catalog',
-          description:
-            ' A manually curated record about the repository/resource/portal etc. itself. Repositories displayed only as Resource Catalogs in the Discovery Portal are not sources of record ingest at this time.',
-        },
-      ],
-    },
-  },
+  // {
+  //   id: 'abstract',
+  //   label: getMetadataName('abstract') || '',
+  //   fields: ['abstract'],
+  //   columns: { isSortable: true, isDefault: false },
+  //   transform: (item): RepositoryMatcherItem['abstract'] => item.abstract || '',
+  //   component: ({
+  //     value,
+  //     isLoading,
+  //   }: {
+  //     value: RepositoryMatcherItem['abstract'];
+  //     isLoading?: boolean;
+  //   }) => <TextCell value={value || ''} isLoading={isLoading} noOfLines={3} />,
+  // },
   {
     id: 'researchDomain',
     label: getMetadataName('genre') || '',
@@ -390,47 +330,47 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
   //     getFilterValues: (value: string) => (value ? [value] : []),
   //   },
   // },
-  {
-    id: 'collectionSize',
-    label: getMetadataName('collectionSize') || '',
-    fields: ['collectionSize'],
-    columns: {
-      isSortable: false,
-      isDefault: true,
-      style: { maxWidth: '160px', minWidth: '160px' },
-    },
-    transform: item => item.collectionSize,
-    getSearchValue: (value: RepositoryMatcherItem['collectionSize']) => {
-      return value?.map(v => `${v.minValue} ${v.unitText || ''}`) || [];
-    },
-    component: ({
-      value,
-    }: {
-      value: RepositoryMatcherItem['collectionSize'];
-      isLoading?: boolean;
-    }) => {
-      return (
-        <VStack>
-          {value?.map((v, i) => (
-            <TextCell
-              key={i}
-              value={v.minValue ? `${v.minValue} ${v.unitText || ''}` : ''}
-              textAlign='end'
-              noOfLines={undefined}
-            >
-              <Text as='span' fontWeight='semibold' fontSize='inherit'>
-                {v.minValue?.toLocaleString() || '-'}
-              </Text>
-              <br />
-              <Text as='span' fontSize='inherit'>
-                {v.unitText}
-              </Text>
-            </TextCell>
-          ))}
-        </VStack>
-      );
-    },
-  },
+  // {
+  //   id: 'collectionSize',
+  //   label: getMetadataName('collectionSize') || '',
+  //   fields: ['collectionSize'],
+  //   columns: {
+  //     isSortable: false,
+  //     isDefault: true,
+  //     style: { maxWidth: '160px', minWidth: '160px' },
+  //   },
+  //   transform: item => item.collectionSize,
+  //   getSearchValue: (value: RepositoryMatcherItem['collectionSize']) => {
+  //     return value?.map(v => `${v.minValue} ${v.unitText || ''}`) || [];
+  //   },
+  //   component: ({
+  //     value,
+  //   }: {
+  //     value: RepositoryMatcherItem['collectionSize'];
+  //     isLoading?: boolean;
+  //   }) => {
+  //     return (
+  //       <VStack>
+  //         {value?.map((v, i) => (
+  //           <TextCell
+  //             key={i}
+  //             value={v.minValue ? `${v.minValue} ${v.unitText || ''}` : ''}
+  //             textAlign='end'
+  //             noOfLines={undefined}
+  //           >
+  //             <Text as='span' fontWeight='semibold' fontSize='inherit'>
+  //               {v.minValue?.toLocaleString() || '-'}
+  //             </Text>
+  //             <br />
+  //             <Text as='span' fontSize='inherit'>
+  //               {v.unitText}
+  //             </Text>
+  //           </TextCell>
+  //         ))}
+  //       </VStack>
+  //     );
+  //   },
+  // },
   {
     id: 'species',
     label: getMetadataName('species') || '',
@@ -527,25 +467,25 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
       filterDescription: getMetadataDescription('topicCategory') || '',
     },
   },
-  {
-    id: 'dateModified',
-    label: getMetadataName('dateModified') || '',
-    fields: ['dateModified'],
-    columns: { isSortable: true, isDefault: true },
-    transform: item => {
-      if (!item.dateModified) return '';
-      return new Date(item.dateModified).toLocaleDateString();
-    },
-    component: ({
-      value,
-      isLoading,
-    }: {
-      value: string;
-      isLoading?: boolean;
-    }) => {
-      return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
-    },
-  },
+  // {
+  //   id: 'dateModified',
+  //   label: getMetadataName('dateModified') || '',
+  //   fields: ['dateModified'],
+  //   columns: { isSortable: true, isDefault: true },
+  //   transform: item => {
+  //     if (!item.dateModified) return '';
+  //     return new Date(item.dateModified).toLocaleDateString();
+  //   },
+  //   component: ({
+  //     value,
+  //     isLoading,
+  //   }: {
+  //     value: string;
+  //     isLoading?: boolean;
+  //   }) => {
+  //     return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
+  //   },
+  // },
   {
     id: 'temporalCoverage',
     label: getMetadataName('temporalCoverage') || '',
@@ -627,81 +567,141 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
   },
   {
-    id: 'usageInfo',
-    label: getMetadataName('usageInfo') || '',
-    fields: ['usageInfo'],
-    columns: { isSortable: true, isDefault: true },
-    transform: item => item.usageInfo || '',
-    getSearchValue: (value: RepositoryMatcherItem['usageInfo']) => {
-      if (typeof value === 'string') {
-        return value;
-      }
-      if (Array.isArray(value)) {
-        return value
-          .map(v => (typeof v === 'string' ? v : v.name || v.url || ''))
-          .filter(v => v);
-      }
-      if (value && typeof value === 'object') {
-        return value.name || value.url || '';
-      }
-      return null;
+    id: 'type',
+    label: getMetadataName('type') || '',
+    fields: ['@type', 'collectionType', 'type'],
+    columns: {
+      isSortable: true,
+      isDefault: true,
+      style: { maxWidth: '180px', minWidth: '180px' },
     },
+    transform: (item): string[] => itemTypes(item),
+    getSortValue: (value: string[]) => (value[0] || '').toLowerCase(),
     component: ({
       value,
       isLoading,
     }: {
-      value: Repository['usageInfo'] | FormattedResource['usageInfo'];
+      value: string[];
       isLoading?: boolean;
-    }) => {
-      if (typeof value === 'string') {
-        if (value.startsWith('http') || value.startsWith('www')) {
-          return (
-            <TextCellWithLink
-              label={value}
-              url={value}
-              isLoading={isLoading}
-              isExternal
-            />
-          );
-        }
-        return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
-      }
-
-      const usageDetails = Array.isArray(value) ? value : value ? [value] : [];
-
-      if (!isLoading && usageDetails.length === 0) {
-        return <TextCell value={''} isLoading={isLoading} noOfLines={1} />;
-      } else if (usageDetails.length > 0) {
-        return (
-          <VStack alignItems='flex-start'>
-            {usageDetails.map((u, i) => (
-              <Box key={i}>
-                {u.url ? (
-                  <TextCellWithLink
-                    label={u.name || u.url}
-                    url={u.url}
-                    isLoading={isLoading}
-                    isExternal
-                  />
-                ) : (
-                  <TextCell value={u.name || ''} isLoading={isLoading} />
-                )}
-                <br />
-                {u?.description && (
-                  <TextCell
-                    value={u.description}
-                    isLoading={isLoading}
-                    noOfLines={3}
-                  />
-                )}
-              </Box>
-            ))}
-          </VStack>
-        );
-      }
-      return <TextCell value={''} isLoading={isLoading} noOfLines={1} />;
+    }) => (
+      <TextCell
+        value={value && value.length ? value.join(', ') : ''}
+        isLoading={isLoading}
+        fontWeight='semibold'
+      />
+    ),
+    filter: {
+      getFilterValues: (value: string[]) => value ?? [],
+    },
+    info: {
+      description:
+        'Type is a Portal-specific classification that indicates how repository content is organized and displayed within the Portal.',
+      filterDescription: getMetadataDescription('type') || '',
+      terms: [
+        {
+          label: 'Dataset Repository',
+          description:
+            'A repository which holds Dataset records. Dataset metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
+        },
+        {
+          label: 'Sample Repository',
+          description:
+            'A repository which holds biological specimen or sample records. Metadata records about samples are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
+        },
+        {
+          label: 'Computational Tool Repository',
+          description:
+            'A repository which holds Computational Tool records. Tool metadata records are mapped and directly ingested into the Discovery Portal on a one-to-one basis.',
+        },
+        {
+          label: 'Data Repository',
+          description:
+            'A repository which holds other types of records. Records of a searchable type are aggregated from the original source and used to create Data Collection records in the Discovery Portal. Multiple records submitted to a Data Repository may end up as a single Data Collection record in the Discovery Portal.',
+        },
+        {
+          label: 'Resource Catalog',
+          description:
+            ' A manually curated record about the repository/resource/portal etc. itself. Repositories displayed only as Resource Catalogs in the Discovery Portal are not sources of record ingest at this time.',
+        },
+      ],
     },
   },
+  // {
+  //   id: 'usageInfo',
+  //   label: getMetadataName('usageInfo') || '',
+  //   fields: ['usageInfo'],
+  //   columns: { isSortable: true, isDefault: true },
+  //   transform: item => item.usageInfo || '',
+  //   getSearchValue: (value: RepositoryMatcherItem['usageInfo']) => {
+  //     if (typeof value === 'string') {
+  //       return value;
+  //     }
+  //     if (Array.isArray(value)) {
+  //       return value
+  //         .map(v => (typeof v === 'string' ? v : v.name || v.url || ''))
+  //         .filter(v => v);
+  //     }
+  //     if (value && typeof value === 'object') {
+  //       return value.name || value.url || '';
+  //     }
+  //     return null;
+  //   },
+  //   component: ({
+  //     value,
+  //     isLoading,
+  //   }: {
+  //     value: Repository['usageInfo'] | FormattedResource['usageInfo'];
+  //     isLoading?: boolean;
+  //   }) => {
+  //     if (typeof value === 'string') {
+  //       if (value.startsWith('http') || value.startsWith('www')) {
+  //         return (
+  //           <TextCellWithLink
+  //             label={value}
+  //             url={value}
+  //             isLoading={isLoading}
+  //             isExternal
+  //           />
+  //         );
+  //       }
+  //       return <TextCell value={value} isLoading={isLoading} noOfLines={1} />;
+  //     }
+
+  //     const usageDetails = Array.isArray(value) ? value : value ? [value] : [];
+
+  //     if (!isLoading && usageDetails.length === 0) {
+  //       return <TextCell value={''} isLoading={isLoading} noOfLines={1} />;
+  //     } else if (usageDetails.length > 0) {
+  //       return (
+  //         <VStack alignItems='flex-start'>
+  //           {usageDetails.map((u, i) => (
+  //             <Box key={i}>
+  //               {u.url ? (
+  //                 <TextCellWithLink
+  //                   label={u.name || u.url}
+  //                   url={u.url}
+  //                   isLoading={isLoading}
+  //                   isExternal
+  //                 />
+  //               ) : (
+  //                 <TextCell value={u.name || ''} isLoading={isLoading} />
+  //               )}
+  //               <br />
+  //               {u?.description && (
+  //                 <TextCell
+  //                   value={u.description}
+  //                   isLoading={isLoading}
+  //                   noOfLines={3}
+  //                 />
+  //               )}
+  //             </Box>
+  //           ))}
+  //         </VStack>
+  //       );
+  //     }
+  //     return <TextCell value={''} isLoading={isLoading} noOfLines={1} />;
+  //   },
+  // },
 ];
 
 export const FILTERABLE_REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] =

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -188,7 +188,7 @@ export const REPOSITORY_MATCHER_COLUMNS: RepositoryMatcherColumn<any>[] = [
     },
     info: {
       description:
-        'Access-level definitions Options include open (freely available), controlled (may include restrictions such as on use), or registered (requires registration to access).',
+        'Access-level definitions options include open (freely available), controlled (may include restrictions such as on use), or registered (requires registration to access).',
       filterDescription: getMetadataDescription('conditionsOfAccess') || '',
       tooltip: getMetadataDescription('conditionsOfAccess') || '',
       terms: [

--- a/src/views/repository-matcher/table-config.tsx
+++ b/src/views/repository-matcher/table-config.tsx
@@ -1,19 +1,6 @@
 import React from 'react';
-import {
-  Box,
-  Circle,
-  HStack,
-  Tag,
-  TagLabel,
-  Text,
-  VStack,
-} from '@chakra-ui/react';
-import { Repository } from 'src/hooks/api/useRepoData';
-import {
-  AccessTypes,
-  DefinedTerm,
-  FormattedResource,
-} from 'src/utils/api/types';
+import { Circle, HStack, Tag, TagLabel, Text, VStack } from '@chakra-ui/react';
+import { AccessTypes, DefinedTerm } from 'src/utils/api/types';
 import {
   formatConditionsOfAccess,
   getColorScheme,

--- a/src/views/repository-matcher/types.ts
+++ b/src/views/repository-matcher/types.ts
@@ -56,6 +56,7 @@ export type RepositoryMatcherColumn<TValue = unknown> = {
   filter?: RepositoryMatcherFilterConfig<TValue>;
   info?: {
     description?: string;
+    tooltip?: string;
     /** Tooltip description for the filters section. */
     filterDescription?: string;
     /** Tooltip description for any sub-terms. */


### PR DESCRIPTION
Addresses [[Request]: Create Repository "Matchmaker" tool/page](https://github.com/NIAID-Data-Ecosystem/niaid-feedback/issues/276#top)

**General**
- [x] Clearly indicate that all repositories listed accept data deposits. For example, modify the subtitle to “Find a suitable repository that accepts research data deposits. Filter by research domain, repository type, and other criteria”
- [x] Be moved to a lower-priority position (e.g., Type),
- [x] Receive less visual emphasis 

**Type**
- [x] Move the Type column towards the right side of the table and the filter option to the bottom.
- [x] Revise the Type description to explain its purpose more clearly. Suggested language:
“Type is used to categorize the nature of genre of the content of the resources” to "Type is a Portal-specific classification that indicates how repository content is organized and displayed within the Portal." 
This text can also replace the text in the data dictionary, “The resource type affects how records from that resource are ingested into the Discovery Portal.”
Repository Classification and Terminology
**Remove duplicate entries.**
- [x] BV-BRC currently appears as both a Dataset Repository and a Resource Catalog. Please change this to Data Collection.

**Remove Columns**
- [x] Collection Size
- [x] Data Modified
- [x] Usage Info
- [x] Abstract

**Hyperlinks**
- [x] Remove hyperlinks to external resources (e.g., all links to Health Condition, Pathogen Species, Species, Measurement Technique, Topic Categories, etc.)
- [x] Eliminate hover-active whenever the hover does not provide additional information and instead is just a hover with the same term or information. Where the links will be removed – please update the aesthetic so that the appearance does not suggest it is dynamic/interactive or clickable behavior.

**Species Information**
- [x] Differentiate between Species and Pathogen Species.
--Please provide us with additional information on how the current Species field was derived. We would like to explore an alternative term for one of these columns to effectively distinguish what the intent is for the information in that column
--Suggest alternative column headers that may better represent the underlying data.

**User Interface**
- [x] Remove button styling from non-button text. Display this content as standard text without hover states or interactive styling.
Add either:
- [x] Hover-over definitions for column headers that provide additional information, or Clickable column headers that link directly to the corresponding section of the data dictionary as within page hyperlinks.

**Clinical Trials Terminology**
- [x] Replace coded clinical trial values with user-friendly terminology. For example, replace NCIT codes with the associated term (e.g., "Parallel Study"). If the associated terminology cannot be displayed, use a more general label such as "clinical trial."

**Data Dictionary**
- [x] Please add some formatting to the data dictionary.
- [x] Provide a section header and descriptive text for the data dictionary
- [x] Please ensure that each column in the table appears in the data dictionary
- [x] Move Type to the bottom
- [x] Please review the data dictionary for consistency with the values displayed in the table and filters. For example, the Access definition includes "embargoed" as an access-level option, but "embargoed" does not appear among the available values. Ensure that all documented options are represented in the interface or remove options that are not currently supported.

**ACDN**
- [ ] Please change [AccessClinicalData@NIAID](https://accessclinicaldata.niaid.nih.gov/) to [accessclinicaldata@NIAID](https://accessclinicaldata.niaid.nih.gov/). We would like this change to be made everywhere throughout the Portal as well.


