### PR TITLE
Add SampleCollection fallback rendering on Resource pages

### DIFF
--- a/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
+++ b/src/components/resource-sections/components/samples/components/SampleCollectionsTable/index.tsx
@@ -2,18 +2,22 @@ import { Skeleton } from '@chakra-ui/react';
 import { SampleTable } from '../SampleTable';
 import { Cell } from '../SampleTable/Cells';
 import { useSampleCollectionItems } from '../../hooks/useSampleCollectionItems';
+import { SAMPLE_COLLECTION_TABLE_CONFIG } from '../../config';
 import {
   getSampleCollectionItemsColumns,
   getSampleCollectionItemsRows,
 } from '../../helpers';
+import { SampleCollection } from 'src/utils/api/types';
 
 interface SampleCollectionItemsTableProps {
   /** The identifier of the parent Dataset/SampleCollection used for the API query. */
   parentIdentifier: string;
+  fallbackSampleCollection?: SampleCollection;
 }
 
 export const SampleCollectionItemsTable = ({
   parentIdentifier,
+  fallbackSampleCollection,
 }: SampleCollectionItemsTableProps) => {
   const { data: samples, isLoading } = useSampleCollectionItems(
     parentIdentifier,
@@ -33,6 +37,28 @@ export const SampleCollectionItemsTable = ({
   }
 
   if (!samples || samples.length === 0) {
+    if (fallbackSampleCollection?.itemListElement?.length) {
+      return (
+        <SampleTable
+          label={SAMPLE_COLLECTION_TABLE_CONFIG.label}
+          caption={SAMPLE_COLLECTION_TABLE_CONFIG.caption}
+          tableProps={{
+            columns: SAMPLE_COLLECTION_TABLE_CONFIG.getColumns(
+              fallbackSampleCollection,
+            ),
+            data: SAMPLE_COLLECTION_TABLE_CONFIG.getRows(
+              fallbackSampleCollection,
+            ),
+            getCells: props => {
+              const data = props.data?.[props.column.property];
+              return Cell.renderCellData?.({ ...props, data });
+            },
+            ...SAMPLE_COLLECTION_TABLE_CONFIG.tableProps,
+          }}
+        />
+      );
+    }
+
     return null;
   }
 

--- a/src/components/resource-sections/components/samples/index.tsx
+++ b/src/components/resource-sections/components/samples/index.tsx
@@ -59,6 +59,7 @@ export const SamplesDisplay = ({
               resourceIdentifier ??
               ''
             }
+            fallbackSampleCollection={sample as SampleCollection}
           />
         )}
       </Box>


### PR DESCRIPTION
This updates the Resource page sample display so SampleCollection records still render when no linked Sample documents are returned from the API lookup.

The existing behavior is preserved: the page first queries for standalone Sample records via isBasisFor.identifier and renders those when available. If that query returns no results, the component now falls back to the embedded sample.itemListElement already present on the Dataset record.

This is needed for sources like NCBI SRA, where samples are embedded in sample.itemListElement rather than indexed as separate linked Sample documents.