### PR TITLE
feat: implement sample ui pills

### DIFF
--- a/src/components/icon/helpers.ts
+++ b/src/components/icon/helpers.ts
@@ -10,6 +10,8 @@ export const getMetadataColor = (property?: string) => {
     return 'cyan.700';
   } else if (property?.toLowerCase() === 'variablemeasured') {
     return 'cyan.700';
+  } else if (property?.toLowerCase() === 'sample') {
+    return 'purple.600';
   } else if (property?.toLowerCase() === 'measurementtechnique') {
     return 'purple.600';
   } else if (property?.toLowerCase() === 'softwarehelp') {
@@ -46,6 +48,8 @@ export const getMetadataTheme = (property?: string) => {
     return 'cyan';
   } else if (property?.toLowerCase() === 'variablemeasured') {
     return 'cyan';
+  } else if (property?.toLowerCase() === 'sample') {
+    return 'purple';
   } else if (property?.toLowerCase() === 'measurementtechnique') {
     return 'purple';
   } else if (property?.toLowerCase() === 'softwarehelp') {

--- a/src/components/metadata/helpers.ts
+++ b/src/components/metadata/helpers.ts
@@ -1,4 +1,8 @@
-import { FormattedResource } from 'src/utils/api/types';
+import {
+  FormattedResource,
+  SampleAggregate,
+  SampleCollection,
+} from 'src/utils/api/types';
 import { formatLicense } from 'src/utils/helpers';
 import { OntologyButtonProps, SearchButtonProps } from './components/buttons';
 import { uniqueId } from 'lodash';
@@ -16,6 +20,7 @@ export const SORT_ORDER = [
   'healthCondition',
   'measurementTechnique',
   'variableMeasured',
+  'sample',
   'funding',
   'license',
   'usageInfo',
@@ -131,6 +136,8 @@ export const generateMetadataContent = (
           data?.infectiousAgent,
           showItems,
         );
+      case 'sample':
+        return createSampleContent(id, property, data?.sample, showItems);
       case 'species':
         return createSpeciesContent(id, property, data?.species, showItems);
       case 'topicCategory':
@@ -657,6 +664,65 @@ const createOutputContent = (
               },
             };
           })
+        : [],
+  };
+};
+
+// Generates content specific to sample data.
+// - SampleAggregate (@type: 'Sample') is displayed as "Population Sample (n)"
+//   where n is sampleQuantity.value when it is a single QuantitativeValue and
+//   the value field is present; falls back to "Population Sample" otherwise.
+// - SampleCollection (@type: 'SampleCollection') is displayed as
+//   "Experimental Samples (n)" when numberOfItems.value is present,
+//   or "Experimental Samples" when it is absent.
+const createSampleContent = (
+  id: FormattedResource['id'],
+  property: string,
+  sample?: FormattedResource['sample'],
+  showItems = true,
+) => {
+  const getSampleDisplayName = (
+    sample: SampleAggregate | SampleCollection,
+  ): string => {
+    if (sample['@type'] === 'SampleCollection') {
+      const sampleCollection = sample as SampleCollection;
+      const count = sampleCollection.numberOfItems?.value;
+      return count !== undefined
+        ? `Experimental Samples (${count.toLocaleString()})`
+        : 'Experimental Samples';
+    }
+    const sampleAggregate = sample as SampleAggregate;
+    if (
+      sampleAggregate.sampleQuantity &&
+      !Array.isArray(sampleAggregate.sampleQuantity) &&
+      sampleAggregate.sampleQuantity.value !== undefined
+    ) {
+      return `Population Sample (${sampleAggregate.sampleQuantity.value.toLocaleString()})`;
+    }
+    return 'Population Sample';
+  };
+
+  const displayName = sample ? getSampleDisplayName(sample) : undefined;
+
+  // Build the resource URL for the #samples anchor so MetadataContent can
+  // render it as a link.
+  const resourceUrl = id ? `/resources?id=${id}#samples` : undefined;
+
+  return {
+    id: `${property}-${id}`,
+    label: 'Sample',
+    property,
+    glyph: property,
+    isDisabled: !sample,
+    url: resourceUrl,
+    items:
+      showItems && displayName
+        ? [
+            {
+              key: uniqueId(`${property}-${id}-label`),
+              name: displayName,
+            },
+          ]
         : [],
   };
 };

--- a/src/utils/feature-flags/index.ts
+++ b/src/utils/feature-flags/index.ts
@@ -68,3 +68,7 @@ export const HIDDEN_SAMPLE_FIELDS = new Set<string>([
   'sample.sampleType.name',
   'sample.sex',
 ]);
+
+// Show the Sample UI pill and corresponding metadata accordion section on dataset cards
+// in non-production environments. To enable in production, set this flag to `true`.
+export const SHOW_SAMPLE_UI_PILL = !isProd;

--- a/src/views/search/components/results-list/components/card/metadata-accordion/index.tsx
+++ b/src/views/search/components/results-list/components/card/metadata-accordion/index.tsx
@@ -27,6 +27,7 @@ import SCHEMA_DEFINITIONS from 'configs/schema-definitions.json';
 import { SchemaDefinitions } from 'scripts/generate-schema-definitions/types';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
+import { SHOW_SAMPLE_UI_PILL } from 'src/utils/feature-flags';
 
 const MetadataBlock = dynamic(
   () => import('src/components/metadata').then(mod => mod.MetadataBlock),
@@ -88,6 +89,8 @@ const MetadataAccordion: React.FC<MetadataAccordionProps> = ({ data }) => {
           funding: data?.funding,
           license: data?.license,
           measurementTechnique: data?.measurementTechnique,
+          // Include sample data only when the feature flag is enabled.
+          ...(SHOW_SAMPLE_UI_PILL ? { sample: data?.sample } : {}),
           species: data?.species,
           usageInfo: data?.usageInfo,
           variableMeasured: data?.variableMeasured,
@@ -224,6 +227,23 @@ const MetadataAccordion: React.FC<MetadataAccordionProps> = ({ data }) => {
                                       );
                                     })}
                                 </MetadataList>
+                                {/* For the sample property, render a bullet-free
+                                    "Show more details" link below the list using
+                                    the top-level url set by createSampleContent. */}
+                                {props.property === 'sample' && url && (
+                                  <NextLink href={url}>
+                                    <Link
+                                      as='div'
+                                      lineHeight='short'
+                                      display='flex'
+                                      ml={4}
+                                    >
+                                      <Text fontSize='xs' lineHeight='short'>
+                                        Show more details
+                                      </Text>
+                                    </Link>
+                                  </NextLink>
+                                )}
                                 {items.length > 3 && (
                                   <NextLink
                                     href={{

--- a/src/views/search/config/fields.ts
+++ b/src/views/search/config/fields.ts
@@ -29,6 +29,7 @@ export const RESULT_FIELDS = [
   'operatingSystem',
   'output',
   'programmingLanguage',
+  'sample',
   'sdPublisher',
   'softwareHelp',
   'softwareRequirements',


### PR DESCRIPTION
# Summary

This PR updates `Dataset `cards on the **Search Results** page to display sample-related metadata.