### PR TITLE
feat-retired-resource-catalog-cards

### DIFF
--- a/src/components/badges/components/CreativeWorkStatus.tsx
+++ b/src/components/badges/components/CreativeWorkStatus.tsx
@@ -1,0 +1,38 @@
+import { FormattedResource } from 'src/utils/api/types';
+import { BadgeWithTooltip, BadgeWithTooltipProps } from 'src/components/badges';
+import SchemaDefinitions from 'configs/schema-definitions.json';
+
+interface CreativeWorkStatusProps extends Omit<BadgeWithTooltipProps, 'value'> {
+  creativeWorkStatus?: FormattedResource['creativeWorkStatus'];
+  type?: FormattedResource['@type'];
+}
+
+// Only renders when the resource has been retired. All other
+// creativeWorkStatus values (Draft, Active, Maintenance, etc.) render
+// nothing, since only "Retired" currently has an associated badge.
+export const CreativeWorkStatus = ({
+  creativeWorkStatus,
+  type,
+  ...props
+}: CreativeWorkStatusProps) => {
+  if (creativeWorkStatus !== 'Retired') {
+    return <></>;
+  }
+
+  const property = SchemaDefinitions['creativeWorkStatus'];
+
+  return (
+    <BadgeWithTooltip
+      colorScheme='red'
+      value='Retired'
+      tooltipLabel={
+        type
+          ? property?.description?.[
+              type as keyof (typeof property)['description']
+            ] || ''
+          : ''
+      }
+      {...props}
+    />
+  );
+};

--- a/src/components/badges/index.ts
+++ b/src/components/badges/index.ts
@@ -1,3 +1,4 @@
 export * from './components/AccessibleForFree';
 export * from './components/BadgeWithTooltip';
 export * from './components/ConditionsOfAccess';
+export * from './components/CreativeWorkStatus';

--- a/src/components/resource-sections/components/banner/index.tsx
+++ b/src/components/resource-sections/components/banner/index.tsx
@@ -71,6 +71,7 @@ const ResourceBanner: React.FC<ResourceBannerProps> = ({ data }) => {
     <TypeBanner
       label={formatAPIResourceTypeForDisplay(type)}
       type={type}
+      creativeWorkStatus={data?.creativeWorkStatus}
       bg='status.info_lt'
       isNiaidFunded={isSourceFundedByNiaid(data.includedInDataCatalog)}
     >

--- a/src/components/resource-sections/components/header/index.tsx
+++ b/src/components/resource-sections/components/header/index.tsx
@@ -7,6 +7,7 @@ import { BookmarkIconButton } from 'src/components/bookmark-buttons/icon-button'
 import { useUserData } from 'src/hooks/useUserData';
 import { ENABLE_AUTH } from 'src/utils/feature-flags';
 import { useAuth } from 'src/hooks/useAuth';
+import { CreativeWorkStatus } from 'src/components/badges';
 
 interface HeaderProps {
   isLoading: boolean;
@@ -15,6 +16,8 @@ interface HeaderProps {
   id?: FormattedResource['id'];
   doi?: FormattedResource['doi'];
   nctid?: FormattedResource['nctid'];
+  type?: FormattedResource['@type'];
+  creativeWorkStatus?: FormattedResource['creativeWorkStatus'];
 }
 
 const Header = ({
@@ -24,6 +27,8 @@ const Header = ({
   id,
   doi,
   nctid,
+  type,
+  creativeWorkStatus,
 }: HeaderProps) => {
   const { user, login } = useAuth();
 
@@ -35,6 +40,9 @@ const Header = ({
     : false;
 
   const showBookmarkButton = ENABLE_AUTH;
+
+  const isRetiredResourceCatalog =
+    type === 'ResourceCatalog' && creativeWorkStatus === 'Retired';
 
   return (
     <>
@@ -121,6 +129,15 @@ const Header = ({
                 />
               )}
             </>
+          )}
+
+          {/* Retired badge for ResourceCatalog records that have been retired. */}
+          {isRetiredResourceCatalog && (
+            <CreativeWorkStatus
+              creativeWorkStatus={creativeWorkStatus}
+              type={type}
+              mt={1}
+            />
           )}
         </VStack>
       </Skeleton>

--- a/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/components/data-access.tsx
@@ -22,6 +22,7 @@ interface DataAccessProps {
   includedInDataCatalog?: FormattedResource['includedInDataCatalog'];
   url?: FormattedResource['url'];
   recordType?: string | null;
+  creativeWorkStatus?: FormattedResource['creativeWorkStatus'];
   children?: React.ReactNode;
   colorScheme?: ButtonProps['colorScheme'];
 }
@@ -29,19 +30,26 @@ interface DataAccessProps {
 const AccessResourceButton: React.FC<{ url: string; colorScheme: string }> = ({
   url,
   colorScheme,
-}) => (
-  <NextLink href={url} target='_blank'>
-    <Button colorScheme={colorScheme} size='sm' rightIcon={<FaArrowRight />}>
-      Access Resource
-    </Button>
-  </NextLink>
-);
+}) => {
+  // Internal routes (e.g. the retired resources page) should navigate
+  // in the same tab; external source links continue to open in a new tab.
+  const isInternalLink = url.startsWith('/');
+
+  return (
+    <NextLink href={url} target={isInternalLink ? undefined : '_blank'}>
+      <Button colorScheme={colorScheme} size='sm' rightIcon={<FaArrowRight />}>
+        Access Resource
+      </Button>
+    </NextLink>
+  );
+};
 
 export const DataAccess: React.FC<DataAccessProps> = ({
   isLoading,
   includedInDataCatalog,
   url,
   recordType,
+  creativeWorkStatus,
   colorScheme = 'secondary',
 }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -97,6 +105,7 @@ export const DataAccess: React.FC<DataAccessProps> = ({
                   recordType,
                   source,
                   url,
+                  creativeWorkStatus,
                 })}
                 colorScheme={colorScheme}
               />

--- a/src/components/resource-sections/components/sidebar/components/external/index.tsx
+++ b/src/components/resource-sections/components/sidebar/components/external/index.tsx
@@ -67,6 +67,7 @@ export const ExternalAccess = ({
           includedInDataCatalog={data?.includedInDataCatalog}
           url={data?.url}
           recordType={data?.['@type']}
+          creativeWorkStatus={data?.creativeWorkStatus}
         />
       </Wrapper>
     </>

--- a/src/components/resource-sections/components/type-banner/index.tsx
+++ b/src/components/resource-sections/components/type-banner/index.tsx
@@ -13,9 +13,19 @@ export interface TypeBannerProps extends FlexProps {
   date?: FormattedResource['date'];
   sourceName?: string[] | null;
   isNiaidFunded?: boolean;
+  creativeWorkStatus?: FormattedResource['creativeWorkStatus'];
 }
 
-export const getTypeColor = (type?: APIResourceType | string) => {
+export const getTypeColor = (
+  type?: APIResourceType | string,
+  isRetired?: boolean,
+) => {
+  // Retired ResourceCatalogs use a gray treatment instead of the usual
+  // per-type colors.
+  if (isRetired) {
+    return { lt: 'gray.800', dk: 'gray.300' };
+  }
+
   const typeLower = type?.toLowerCase();
   let lt = 'status.info';
   let dk = 'niaid.500';
@@ -44,9 +54,14 @@ const TypeBanner: React.FC<TypeBannerProps> = ({
   children,
   pl,
   isNiaidFunded,
+  creativeWorkStatus,
   ...props
 }) => {
-  const colorScheme = getTypeColor(type);
+  // Retired ResourceCatalogs get the gray banner treatment; every other
+  // type/status combination keeps its standard per-type colors.
+  const isRetired =
+    type === 'ResourceCatalog' && creativeWorkStatus === 'Retired';
+  const colorScheme = getTypeColor(type, isRetired);
   const abstract = SCHEMA_DEFINITIONS['@type']?.['abstract'];
   const description = SCHEMA_DEFINITIONS['@type']?.['description'];
 
@@ -97,7 +112,7 @@ const TypeBanner: React.FC<TypeBannerProps> = ({
         {isNiaidFunded && (
           <StyledLabel
             _before={{
-              bg: colorScheme['dk'],
+              bg: isRetired ? colorScheme['lt'] : colorScheme['dk'],
             }}
           >
             <Text

--- a/src/components/resource-sections/index.tsx
+++ b/src/components/resource-sections/index.tsx
@@ -75,6 +75,8 @@ const Sections = ({
         id={data?.id}
         doi={data?.doi}
         nctid={data?.nctid}
+        type={data?.['@type']}
+        creativeWorkStatus={data?.creativeWorkStatus}
       />
       {/* Banner showing data type and publish date. For computational tools, operating system info is displayed when available. */}
       {data?.author && <ResourceAuthors authors={data.author} />}

--- a/src/components/source-logo/helpers.ts
+++ b/src/components/source-logo/helpers.ts
@@ -54,11 +54,19 @@ export const getAccessResourceURL = ({
   recordType,
   source,
   url,
+  creativeWorkStatus,
 }: {
   recordType: string | null | undefined;
   source: IncludedInDataCatalog;
   url?: FormattedResource['url'];
+  creativeWorkStatus?: FormattedResource['creativeWorkStatus'];
 }) => {
+  // Retired ResourceCatalogs should send users to the retired resources
+  // page in the Knowledge Center instead of the usual external/source link.
+  if (recordType === 'ResourceCatalog' && creativeWorkStatus === 'Retired') {
+    return '/knowledge-center/retired-resources';
+  }
+
   return recordType === 'ResourceCatalog'
     ? url ?? ''
     : getSourceLogoLinkOut(source);

--- a/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
+++ b/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { Flex, Tooltip, Text, Button } from '@chakra-ui/react';
 import { FormattedResource } from 'src/utils/api/types';
 import { isSourceFundedByNiaid } from 'src/utils/helpers/sources';
-import { ConditionsOfAccess } from 'src/components/badges';
+import { ConditionsOfAccess, CreativeWorkStatus } from 'src/components/badges';
 import { HasAPI } from 'src/components/badges/components/HasAPI';
 import { MetadataLabel } from 'src/components/metadata';
 import { ScrollContainer } from 'src/components/scroll-container';
@@ -33,6 +33,7 @@ export const ResourceCatalogCard = ({
     date,
     conditionsOfAccess,
     hasAPI,
+    creativeWorkStatus,
     about,
     description,
   } = data || {};
@@ -107,7 +108,9 @@ export const ResourceCatalogCard = ({
               >
                 <Text fontSize='13px'>{date}</Text>
               </Tooltip>
-              {(conditionsOfAccess || hasAPI) && (
+              {(conditionsOfAccess ||
+                hasAPI ||
+                creativeWorkStatus === 'Retired') && (
                 <Flex
                   justifyContent={['flex-start']}
                   alignItems='center'
@@ -132,6 +135,12 @@ export const ResourceCatalogCard = ({
                       size='sm'
                     />
                   )}
+                  <CreativeWorkStatus
+                    creativeWorkStatus={creativeWorkStatus}
+                    type={data?.['@type']}
+                    mx={0.5}
+                    size='sm'
+                  />
                 </Flex>
               )}
             </Flex>

--- a/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
+++ b/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
@@ -59,6 +59,12 @@ export const ResourceCatalogCard = ({
 
   const shouldShowDescription = !showAllTypes;
 
+  // Retired ResourceCatalog cards use a gray treatment throughout to
+  // visually communicate that the resource is no longer active.
+  const isRetired =
+    type === 'ResourceCatalog' && creativeWorkStatus === 'Retired';
+  const cardBg = isRetired ? 'gray.100' : 'white';
+
   const linkProps = id
     ? {
         href: {
@@ -70,12 +76,13 @@ export const ResourceCatalogCard = ({
     : undefined;
 
   return (
-    <CompactCard.Base isLoading={isLoading}>
+    <CompactCard.Base isLoading={isLoading} bg={cardBg}>
       <CompactCard.Banner
         label={formatAPIResourceTypeForDisplay(type || 'ResourceCatalog')}
         type={type || 'ResourceCatalog'}
         isNiaidFunded={isSourceFundedByNiaid(includedInDataCatalog)}
         isLoading={isLoading}
+        creativeWorkStatus={creativeWorkStatus}
       />
 
       <CompactCard.Header isLoading={isLoading}>
@@ -91,7 +98,7 @@ export const ResourceCatalogCard = ({
         <Skeleton isLoaded={!isLoading} minHeight='30px'>
           {date && (
             <Flex
-              bg='white'
+              bg={cardBg}
               fontWeight='semibold'
               whiteSpace='nowrap'
               alignItems='flex-start'
@@ -150,7 +157,7 @@ export const ResourceCatalogCard = ({
         {/* Content types */}
         <Skeleton isLoaded={!isLoading} px={-1}>
           {aboutItems.length > 0 && (
-            <Flex bg='white' direction='column'>
+            <Flex bg={cardBg} direction='column'>
               <MetadataLabel label='Content Types' />
               <ScrollContainer overflow='auto' maxHeight='200px'>
                 <SearchableItems

--- a/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
+++ b/src/views/search/components/results-list/components/carousel-compact-card/resource-catalog-card/index.tsx
@@ -63,7 +63,7 @@ export const ResourceCatalogCard = ({
   // visually communicate that the resource is no longer active.
   const isRetired =
     type === 'ResourceCatalog' && creativeWorkStatus === 'Retired';
-  const cardBg = isRetired ? 'gray.100' : 'white';
+  const cardBg = isRetired ? 'page.alt' : 'white';
 
   const linkProps = id
     ? {

--- a/src/views/search/components/search-results-tabs-controller/index.tsx
+++ b/src/views/search/components/search-results-tabs-controller/index.tsx
@@ -39,6 +39,7 @@ const CAROUSEL_RESULTS_FIELDS = [
   'about',
   'alternateName',
   'conditionsOfAccess',
+  'creativeWorkStatus',
   'date',
   'description',
   'hasAPI',


### PR DESCRIPTION
# Summary

This PR improves the visibility of **retired resource catalog records** by:

- applying updated background styling to retired resource catalog cards
- displaying **Retired** badges on resource cards and resource pages
- updating the **Access Resource** link on the Resource page

Related issue: https://github.com/NIAID-Data-Ecosystem/nde-portal/issues/445