### PR TITLE
feat(any-no-filters): prevent other options from being rendered)

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -32,6 +32,7 @@ import { useActiveVizIds } from 'src/views/search/components/summary/hooks/useAc
 import {
   queryFilterString2Object,
   queryFilterObject2String,
+  sanitizeExistsFilterValues,
 } from 'src/views/search/components/filters/utils/query-string';
 import { FilterTags } from 'src/views/search/components/filters/components/tag';
 import { SearchResultsFetchedProvider } from 'src/views/search/context/search-results-fetched-context';
@@ -125,9 +126,15 @@ const Search: NextPage<{
       //     : value,
       // );
 
+      const prevValues = selectedFilters[facet] || [];
+
+      // Checking "Any"/"No" clears everything else for this facet, and
+      // checking a normal value clears "Any"/"No" if it was active.
+      const sanitizedValues = sanitizeExistsFilterValues(values, prevValues);
+
       const updatedFilterString = queryFilterObject2String({
         ...selectedFilters,
-        [facet]: values,
+        [facet]: sanitizedValues,
       });
 
       handleUpdate({

--- a/src/views/search/components/filters/components/filters.tsx
+++ b/src/views/search/components/filters/components/filters.tsx
@@ -9,7 +9,10 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { useFilterQueries } from '../hooks/useFilterQueries';
-import { queryFilterObject2String } from '../utils/query-string';
+import {
+  queryFilterObject2String,
+  sanitizeExistsFilterValues,
+} from '../utils/query-string';
 import { SelectedFilterType } from '../types';
 import { useRouter } from 'next/router';
 import { FiltersSection } from './section';
@@ -197,7 +200,16 @@ export const Filters = React.memo(
 
     const handleSelectedFilters = useCallback(
       (values: string[], facet: string) => {
-        const updatedValues = values.map(value => {
+        // Normalize the facet's previous selection to plain strings, mirroring
+        // how `selected` is derived for each filter section below.
+        const prevValues = (selectedFilters[facet] || []).map(value =>
+          typeof value === 'object' ? Object.keys(value)[0] : value,
+        );
+
+        // Checking "Any"/"No" clears everything else for this facet.
+        const sanitizedValues = sanitizeExistsFilterValues(values, prevValues);
+
+        const updatedValues = sanitizedValues.map(value => {
           // return object with inverted facet + key for exists values
           if (value === '-_exists_' || value === '_exists_') {
             return { [value]: [facet] };

--- a/src/views/search/components/filters/components/list.tsx
+++ b/src/views/search/components/filters/components/list.tsx
@@ -225,14 +225,26 @@ export const FiltersList: React.FC<FiltersListProps> = React.memo(
     terms: resultTerms,
   }) => {
     // filter out terms that are undefined or null or empty strings
-    const terms = useMemo(
-      () =>
+    const terms = useMemo(() => {
+      const filteredTerms =
         resultTerms?.filter(
           term =>
             term.term !== undefined && term.term !== null && term.term !== '',
-        ) || [],
-      [resultTerms],
-    );
+        ) || [];
+
+      // If the user has checked "Any <filter>" (_exists_) or
+      // "No <filter>" (-_exists_), the other facet values (and the opposite
+      // exists/not-exists option) are no longer relevant to choose from, so
+      // hide them and only show the one option the user selected.
+      if (selectedFilters.includes('_exists_')) {
+        return filteredTerms.filter(term => term.term === '_exists_');
+      }
+      if (selectedFilters.includes('-_exists_')) {
+        return filteredTerms.filter(term => term.term === '-_exists_');
+      }
+
+      return filteredTerms;
+    }, [resultTerms, selectedFilters]);
 
     const [searchTerm, setSearchTerm] = useState('');
     const [debouncedSearchTerm] = useDebounceValue(searchTerm, 300);

--- a/src/views/search/components/filters/index.ts
+++ b/src/views/search/components/filters/index.ts
@@ -32,4 +32,5 @@ export {
   queryFilterString2Object,
   normalizeFilterValues,
   getSelectedFilterDisplay,
+  sanitizeExistsFilterValues,
 } from './utils/query-string';

--- a/src/views/search/components/filters/utils/query-string.ts
+++ b/src/views/search/components/filters/utils/query-string.ts
@@ -157,3 +157,55 @@ export const getSelectedFilterDisplay = (
     return value;
   });
 };
+
+/**
+ * Resolves mutual exclusivity between "Any" (_exists_) / "No" (-_exists_)
+ * and a facet's other values:
+ *   - Checking "Any" or "No" deselects every other value for that facet,
+ *     including the opposite of itself.
+ *   - Checking a normal value while "Any"/"No" is still active drops
+ *     "Any"/"No" so only the real value(s) remain.
+ *
+ * The second rule is a no-op for the sidebar checkbox list (FiltersList),
+ * since once "Any"/"No" is checked there, every other checkbox is hidden
+ * and can't be clicked until "Any"/"No" is unchecked first. It's load-bearing
+ * for the Visual Summary charts, though: chart slices aren't hidden the same
+ * way, so a user can click a real value's slice (e.g. "Influenza") while
+ * "Any"/"No" is still selected from the sidebar, producing exactly the
+ * mixed state this rule cleans up.
+ *
+ * `values` is the full new set of checked values for the facet (as emitted
+ * by the checkbox group or chart click handler); `prevValues` is what was
+ * selected before this change. Works for both plain string values and the
+ * `{ [key]: string[] }` object form used for _exists_/-_exists_ in
+ * SelectedFilterType.
+ */
+export const sanitizeExistsFilterValues = <T extends SelectedFilterValueType>(
+  values: T[],
+  prevValues: T[],
+): T[] => {
+  const normalize = (v: T): string =>
+    typeof v === 'object' ? Object.keys(v)[0] : v;
+
+  const isExistsType = (v: T) => {
+    const key = normalize(v);
+    return key === '_exists_' || key === '-_exists_';
+  };
+
+  const prevKeys = prevValues.map(normalize);
+  const added = values.filter(v => !prevKeys.includes(normalize(v)));
+  const addedExists = added.find(isExistsType);
+
+  // "Any"/"No" was just checked: it overrides every other selection.
+  if (addedExists) {
+    return [addedExists];
+  }
+
+  // A normal value is checked while "Any"/"No" is still present from a
+  // previous selection (only reachable via Visual Summary charts): drop "Any"/"No" so only the normal value(s) remain.
+  if (values.some(v => !isExistsType(v)) && values.some(isExistsType)) {
+    return values.filter(v => !isExistsType(v));
+  }
+
+  return values;
+};


### PR DESCRIPTION
# Summary

This PR hides filter options in the **Search Results** page filter panel when users select "any {filter name}" or "no {filter name}".

Related issue: https://github.com/NIAID-Data-Ecosystem/nde-portal/issues/464#issuecomment-4783019132
