### PR TITLE
fix: filter handling and improve error display in saved queries

### DIFF
--- a/src/components/bookmark-buttons/icon-button.tsx
+++ b/src/components/bookmark-buttons/icon-button.tsx
@@ -30,6 +30,7 @@ export const BookmarkIconButton: React.FC<
         isRound={true}
         borderRadius='50%'
         size='sm'
+        colorScheme='blue'
         {...props}
       />
     </Tooltip>

--- a/src/hooks/useUserData/helpers.ts
+++ b/src/hooks/useUserData/helpers.ts
@@ -116,3 +116,45 @@ export const parseSavedQueries = (queries: SavedQuery[]): SavedQuery[] =>
     ...query,
     filters: parseSavedQueryFilters(query.filters),
   }));
+
+/**
+ * Stringify a value with object keys sorted recursively, so that two
+ * structurally-equal filter objects compare equal regardless of key order.
+ * Array order is preserved (it is meaningful for filters such as
+ * `date: [start, end, ...]`).
+ */
+export const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(
+        key =>
+          `${JSON.stringify(key)}:${stableStringify(
+            (value as Record<string, unknown>)[key],
+          )}`,
+      );
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+};
+
+/**
+ * Locate a saved query by identity (`query` string + structurally-equal
+ * `filters`) rather than by position. Deleting by index is fragile: the
+ * favorites API removes by index, so any stale index (e.g. computed before a
+ * prior delete shrank the list) can point past the end of the server array and
+ * return "Index out of range". Resolving the index from the freshest list at
+ * call time keeps deletes correct regardless of order. Returns -1 if absent.
+ */
+export const findSavedQueryIndex = (
+  queries: SavedQuery[],
+  target: Pick<SavedQuery, 'query' | 'filters'>,
+): number =>
+  queries.findIndex(
+    query =>
+      query.query === target.query &&
+      stableStringify(query.filters) === stableStringify(target.filters),
+  );

--- a/src/hooks/useUserData/index.test.tsx
+++ b/src/hooks/useUserData/index.test.tsx
@@ -1,0 +1,206 @@
+import { ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { UserDataProvider, useUserData } from './index';
+import { findSavedQueryIndex } from './helpers';
+import { SavedQuery } from './types';
+
+/**
+ * Regression coverage for the "Index out of range" 400 that occurred when
+ * deleting multiple saved queries in a row. The favorites API deletes a saved
+ * search by its array index, so a stale index (computed before a prior delete
+ * shrank the list) pointed past the end of the server array. `removeSavedQuery`
+ * now resolves the index by identity against the freshest list at call time, so
+ * sequential deletes always send a valid index.
+ *
+ * In Jest, NODE_ENV is "test" (not "development"), so `useUserData` uses the real
+ * `fetch` path; we mock `global.fetch` as a stateful, index-based server that
+ * mirrors the production endpoint — including the 400 it returns for a bad index.
+ */
+
+const makeQuery = (query: string, total: number): SavedQuery => ({
+  query,
+  name: `Search: ${query}`,
+  total,
+  filters: {},
+});
+
+interface DeleteCall {
+  index: number;
+}
+
+/**
+ * Build a fetch mock backed by an in-memory `favorite_searches` array that
+ * deletes by index and returns 400 "Index out of range." for an out-of-bounds
+ * index — exactly like the real API.
+ */
+const createServerFetch = (initial: SavedQuery[]) => {
+  let favorite_searches = [...initial];
+  const deleteCalls: DeleteCall[] = [];
+
+  const respond = (status: number, body: unknown) =>
+    Promise.resolve({
+      status,
+      ok: status >= 200 && status < 300,
+      text: async () => JSON.stringify(body),
+    } as Response);
+
+  const fetchMock = jest.fn(
+    (url: string, init?: RequestInit): Promise<Response> => {
+      const path = url.replace(/^https?:\/\/[^/]+/, '');
+      const method = init?.method ?? 'GET';
+
+      if (path === '/user/data' && method === 'GET') {
+        return respond(200, { favorite_searches, favorite_datasets: [] });
+      }
+
+      if (path === '/user/data/favorites/searches' && method === 'DELETE') {
+        const { index } = JSON.parse(String(init?.body)) as DeleteCall;
+        deleteCalls.push({ index });
+        if (index < 0 || index >= favorite_searches.length) {
+          return respond(400, {
+            code: 400,
+            success: false,
+            error: 'Index out of range.',
+          });
+        }
+        favorite_searches = favorite_searches.filter((_, i) => i !== index);
+        return respond(200, {
+          message: 'removed',
+          favorite_searches,
+        });
+      }
+
+      return respond(404, { error: 'not found' });
+    },
+  );
+
+  return {
+    fetchMock,
+    deleteCalls,
+    getSearches: () => favorite_searches,
+  };
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <UserDataProvider>{children}</UserDataProvider>
+);
+
+describe('useUserData', () => {
+  beforeEach(() => {
+    // Silence the hook's [favorites test] console grouping.
+    jest.spyOn(console, 'group').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('deletes multiple saved queries sequentially without an out-of-range 400', async () => {
+    const queryA = makeQuery('malaria', 10);
+    const queryB = makeQuery('influenza', 20);
+    const server = createServerFetch([queryA, queryB]);
+    global.fetch = server.fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+
+    // Profile loads on mount.
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(2));
+
+    // Delete the FIRST item: it sits at index 0, the list shrinks to [influenza].
+    let res: any;
+    await act(async () => {
+      res = await result.current.removeSavedQuery(queryA);
+    });
+    expect(res.status).toBe(200);
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(1));
+
+    // Delete the remaining item. With the old index-based code this still sent
+    // the original index (1) against a length-1 array → 400. Identity resolution
+    // now sends index 0.
+    await act(async () => {
+      res = await result.current.removeSavedQuery(queryB);
+    });
+    expect(res.status).toBe(200);
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(0));
+
+    // No delete ever produced a 400, and every index sent was in range.
+    const statuses = server.deleteCalls.map(c => c.index);
+    expect(statuses).toEqual([0, 0]);
+    expect(server.getSearches()).toHaveLength(0);
+  });
+
+  it('deletes the correct query when two share a query string but differ in filters', async () => {
+    // Same `query`, different `filters` — must be treated as separate entries.
+    const malariaDataset: SavedQuery = {
+      query: 'malaria',
+      name: 'malaria (datasets)',
+      total: 5,
+      filters: { '@type': ['Dataset'] },
+    };
+    const malariaTool: SavedQuery = {
+      query: 'malaria',
+      name: 'malaria (tools)',
+      total: 3,
+      filters: { '@type': ['ComputationalTool'] },
+    };
+    const server = createServerFetch([malariaDataset, malariaTool]);
+    global.fetch = server.fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(2));
+
+    // Remove only the Dataset variant (index 0).
+    await act(async () => {
+      await result.current.removeSavedQuery(malariaDataset);
+    });
+
+    expect(server.deleteCalls).toEqual([{ index: 0 }]);
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(1));
+    // The surviving entry is the Tool variant, untouched.
+    expect(result.current.savedQueries[0].filters).toEqual({
+      '@type': ['ComputationalTool'],
+    });
+  });
+
+  it('no-ops (no fetch) when removing a query that is not saved', async () => {
+    const server = createServerFetch([makeQuery('malaria', 10)]);
+    global.fetch = server.fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.removeSavedQuery(makeQuery('not-saved', 0));
+    });
+
+    expect(server.deleteCalls).toHaveLength(0);
+    expect(result.current.savedQueries).toHaveLength(1);
+  });
+});
+
+describe('findSavedQueryIndex', () => {
+  const a = makeQuery('a', 1);
+  const b: SavedQuery = {
+    query: 'b',
+    name: 'b',
+    total: 1,
+    filters: { type: ['Dataset'] },
+  };
+
+  it('matches on query + structurally-equal filters regardless of key order', () => {
+    expect(
+      findSavedQueryIndex([a, b], {
+        query: 'b',
+        filters: { type: ['Dataset'] },
+      }),
+    ).toBe(1);
+  });
+
+  it('returns -1 when filters differ', () => {
+    expect(
+      findSavedQueryIndex([a, b], { query: 'b', filters: { type: ['Tool'] } }),
+    ).toBe(-1);
+  });
+});

--- a/src/hooks/useUserData/index.test.tsx
+++ b/src/hooks/useUserData/index.test.tsx
@@ -164,6 +164,83 @@ describe('useUserData', () => {
     });
   });
 
+  it('sets an error when a delete fails, and clears it on the next success', async () => {
+    const queryA = makeQuery('malaria', 10);
+    const queryB = makeQuery('influenza', 20);
+    const server = createServerFetch([queryA, queryB]);
+    // Force the first DELETE to fail like the real API can.
+    const failingFetch = jest.fn((url: string, init?: RequestInit) => {
+      const path = url.replace(/^https?:\/\/[^/]+/, '');
+      if (
+        path === '/user/data/favorites/searches' &&
+        init?.method === 'DELETE'
+      ) {
+        failingFetch.mockImplementation(server.fetchMock); // subsequent calls succeed
+        return Promise.resolve({
+          status: 400,
+          ok: false,
+          text: async () =>
+            JSON.stringify({
+              code: 400,
+              success: false,
+              error: 'Bad request.',
+            }),
+        } as Response);
+      }
+      return server.fetchMock(url, init);
+    });
+    global.fetch = failingFetch as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+    await waitFor(() => expect(result.current.savedQueries).toHaveLength(2));
+
+    // Failing delete → error banner message is set.
+    await act(async () => {
+      await result.current.removeSavedQuery(queryA);
+    });
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'Unable to remove this saved query. Please try again.',
+      ),
+    );
+
+    // A subsequent successful delete clears the error.
+    await act(async () => {
+      await result.current.removeSavedQuery(queryA);
+    });
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  it('clearError dismisses the current error', async () => {
+    const server = createServerFetch([]);
+    global.fetch = server.fetchMock as unknown as typeof fetch;
+    const { result } = renderHook(() => useUserData(), { wrapper });
+
+    // Removing a dataset that doesn't exist still calls DELETE; point fetch at a
+    // failing response to populate the error, then dismiss it.
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 500,
+        ok: false,
+        text: async () => JSON.stringify({ error: 'server error' }),
+      } as Response),
+    ) as unknown as typeof fetch;
+
+    await act(async () => {
+      await result.current.removeSavedDataset('does-not-exist');
+    });
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'Unable to remove this saved resource. Please try again.',
+      ),
+    );
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
   it('no-ops (no fetch) when removing a query that is not saved', async () => {
     const server = createServerFetch([makeQuery('malaria', 10)]);
     global.fetch = server.fetchMock as unknown as typeof fetch;

--- a/src/hooks/useUserData/index.test.tsx
+++ b/src/hooks/useUserData/index.test.tsx
@@ -200,7 +200,7 @@ describe('useUserData', () => {
     });
     await waitFor(() =>
       expect(result.current.error).toBe(
-        'Unable to remove this saved query. Please try again.',
+        `Couldn't remove the saved search "malaria". Please try again.`,
       ),
     );
 
@@ -231,7 +231,7 @@ describe('useUserData', () => {
     });
     await waitFor(() =>
       expect(result.current.error).toBe(
-        'Unable to remove this saved resource. Please try again.',
+        `Couldn't remove this saved resource. Please try again.`,
       ),
     );
 
@@ -239,6 +239,83 @@ describe('useUserData', () => {
       result.current.clearError();
     });
     expect(result.current.error).toBeNull();
+  });
+
+  it('names the dataset in the error when a dataset removal fails', async () => {
+    const dataset = { dataset_id: 'ds-1', name: 'Malaria Atlas' };
+    const fetchMock = jest.fn((url: string, init?: RequestInit) => {
+      const path = url.replace(/^https?:\/\/[^/]+/, '');
+      const method = init?.method ?? 'GET';
+      if (path === '/user/data' && method === 'GET') {
+        return Promise.resolve({
+          status: 200,
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              favorite_searches: [],
+              favorite_datasets: [dataset],
+            }),
+        } as Response);
+      }
+      // Fail the delete.
+      return Promise.resolve({
+        status: 500,
+        ok: false,
+        text: async () => JSON.stringify({ error: 'server error' }),
+      } as Response);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+    await waitFor(() => expect(result.current.savedDatasets).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.removeSavedDataset('ds-1');
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        `Couldn't remove "Malaria Atlas". Please try again.`,
+      ),
+    );
+  });
+
+  it('stays silent when the profile request returns 401 (logged out)', async () => {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        status: 401,
+        ok: false,
+        text: async () => JSON.stringify({ error: 'unauthorized' }),
+      } as Response),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // Flush any state updates from getProfile before asserting it stayed silent.
+    await act(async () => {});
+    expect(result.current.error).toBeNull();
+    expect(result.current.savedQueries).toHaveLength(0);
+  });
+
+  it('surfaces an error when the profile request fails with a non-401 status', async () => {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        status: 500,
+        ok: false,
+        text: async () => JSON.stringify({ error: 'server error' }),
+      } as Response),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUserData(), { wrapper });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'Unable to load your saved queries and resources. Please refresh to try again.',
+      ),
+    );
   });
 
   it('no-ops (no fetch) when removing a query that is not saved', async () => {

--- a/src/hooks/useUserData/index.tsx
+++ b/src/hooks/useUserData/index.tsx
@@ -60,6 +60,11 @@ function useUserDataState() {
 
   const [savedDatasets, setSavedDatasets] = useState<SavedDataset[]>([]);
 
+  // Last failed saved-items mutation, surfaced to the UI as an error banner.
+  // Cleared whenever a subsequent mutation succeeds (or on manual dismiss).
+  const [error, setError] = useState<string | null>(null);
+  const clearError = useCallback(() => setError(null), []);
+
   // Mirror the latest savedQueries so identity-based deletes resolve the index
   // from the freshest list (never a stale render closure). Updated every render.
   const savedQueriesRef = useRef<SavedQuery[]>(savedQueries);
@@ -329,11 +334,14 @@ function useUserDataState() {
         '/user/data/favorites/searches',
         { ...search, filters: formatSavedQueryFilters(search.filters) },
       );
-      if (result && 'body' in result && result.ok && result.body) {
+      if (result && 'body' in result && result.ok) {
+        setError(null);
         const body = result.body as { favorite_searches?: SavedQuery[] };
         if (Array.isArray(body.favorite_searches)) {
           setSavedQueries(parseSavedQueries(body.favorite_searches));
         }
+      } else {
+        setError('Unable to save this query. Please try again.');
       }
       return result;
     },
@@ -348,6 +356,7 @@ function useUserDataState() {
       const index = findSavedQueryIndex(savedQueriesRef.current, search);
       if (index === -1) {
         // Already gone (e.g. removed by another action) — nothing to do.
+        setError(null);
         return {
           status: 200,
           ok: true,
@@ -359,11 +368,14 @@ function useUserDataState() {
         '/user/data/favorites/searches',
         { index },
       );
-      if (result && 'body' in result && result.ok && result.body) {
+      if (result && 'body' in result && result.ok) {
+        setError(null);
         const body = result.body as { favorite_searches?: SavedQuery[] };
         if (Array.isArray(body.favorite_searches)) {
           setSavedQueries(parseSavedQueries(body.favorite_searches));
         }
+      } else {
+        setError('Unable to remove this saved query. Please try again.');
       }
       return result;
     },
@@ -377,11 +389,14 @@ function useUserDataState() {
         '/user/data/favorites/datasets',
         dataset,
       );
-      if (result && 'body' in result && result.ok && result.body) {
+      if (result && 'body' in result && result.ok) {
+        setError(null);
         const body = result.body as { favorite_datasets?: SavedDataset[] };
         if (Array.isArray(body.favorite_datasets)) {
           setSavedDatasets(body.favorite_datasets);
         }
+      } else {
+        setError('Unable to save this resource. Please try again.');
       }
       return result;
     },
@@ -397,11 +412,14 @@ function useUserDataState() {
           dataset_id: datasetId,
         },
       );
-      if (result && 'body' in result && result.ok && result.body) {
+      if (result && 'body' in result && result.ok) {
+        setError(null);
         const body = result.body as { favorite_datasets?: SavedDataset[] };
         if (Array.isArray(body.favorite_datasets)) {
           setSavedDatasets(body.favorite_datasets);
         }
+      } else {
+        setError('Unable to remove this saved resource. Please try again.');
       }
       return result;
     },
@@ -413,6 +431,8 @@ function useUserDataState() {
     savedQueries,
     savedDatasets,
     isDevMode,
+    error,
+    clearError,
     getProfile,
     updatePreferenceField,
     addSavedQuery,

--- a/src/hooks/useUserData/index.tsx
+++ b/src/hooks/useUserData/index.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { MOCK_SAVED_DATASETS } from './mocks/saved_datasets';
 import {
   SavedDataset,
@@ -8,7 +16,11 @@ import {
   UserProfile,
 } from './types';
 import { MOCK_SAVED_QUERIES } from './mocks/saved_queries';
-import { formatSavedQueryFilters, parseSavedQueries } from './helpers';
+import {
+  findSavedQueryIndex,
+  formatSavedQueryFilters,
+  parseSavedQueries,
+} from './helpers';
 
 const DEFAULT_PREFERENCES: UserPreferences = {
   ai_toggle_preference: false,
@@ -40,13 +52,18 @@ const apiUrl =
 const API_BASE_URL = apiUrl.replace(/\/v1$/, '');
 const isDevMode = process.env.NODE_ENV === 'development';
 
-export function useUserData() {
+function useUserDataState() {
   const [preferences, setPreferences] =
     useState<UserPreferences>(DEFAULT_PREFERENCES);
 
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
 
   const [savedDatasets, setSavedDatasets] = useState<SavedDataset[]>([]);
+
+  // Mirror the latest savedQueries so identity-based deletes resolve the index
+  // from the freshest list (never a stale render closure). Updated every render.
+  const savedQueriesRef = useRef<SavedQuery[]>(savedQueries);
+  savedQueriesRef.current = savedQueries;
 
   const mockUserDataRef = useRef<{ profile: UserProfile }>({
     // Clone the arrays so the mock API's push/filter operations don't mutate
@@ -324,7 +341,19 @@ export function useUserData() {
   );
 
   const removeSavedQuery = useCallback(
-    async (index: number) => {
+    async (search: Pick<SavedQuery, 'query' | 'filters'>) => {
+      // Resolve the index from the freshest list at call time. The favorites API
+      // deletes by index, so a stale index (e.g. computed before a prior delete
+      // shrank the list) would return "Index out of range".
+      const index = findSavedQueryIndex(savedQueriesRef.current, search);
+      if (index === -1) {
+        // Already gone (e.g. removed by another action) — nothing to do.
+        return {
+          status: 200,
+          ok: true,
+          body: { favorite_searches: savedQueriesRef.current },
+        };
+      }
       const result = await callUserDataApi(
         'DELETE',
         '/user/data/favorites/searches',
@@ -391,4 +420,34 @@ export function useUserData() {
     addSavedDataset,
     removeSavedDataset,
   };
+}
+
+type UserDataContextValue = ReturnType<typeof useUserDataState>;
+
+const UserDataContext = createContext<UserDataContextValue | undefined>(
+  undefined,
+);
+
+/**
+ * Holds the single source of truth for the signed-in user's saved data
+ * (preferences, saved queries, saved datasets). Mounting this once (in `_app`)
+ * means every consumer shares one fetched-and-mutated state, so a delete in one
+ * component re-syncs the rest. Without it, each `useUserData()` call kept its own
+ * copy and index-based deletes drifted out of range.
+ */
+export function UserDataProvider({ children }: { children: ReactNode }) {
+  const value = useUserDataState();
+  return (
+    <UserDataContext.Provider value={value}>
+      {children}
+    </UserDataContext.Provider>
+  );
+}
+
+export function useUserData() {
+  const context = useContext(UserDataContext);
+  if (context === undefined) {
+    throw new Error('useUserData must be used within a UserDataProvider');
+  }
+  return context;
 }

--- a/src/hooks/useUserData/index.tsx
+++ b/src/hooks/useUserData/index.tsx
@@ -52,6 +52,11 @@ const apiUrl =
 const API_BASE_URL = apiUrl.replace(/\/v1$/, '');
 const isDevMode = process.env.NODE_ENV === 'development';
 
+// Keep item labels in error banners short so a long query/title doesn't blow out
+// the banner.
+const truncateLabel = (text: string, max = 60) =>
+  text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
 function useUserDataState() {
   const [preferences, setPreferences] =
     useState<UserPreferences>(DEFAULT_PREFERENCES);
@@ -69,6 +74,11 @@ function useUserDataState() {
   // from the freshest list (never a stale render closure). Updated every render.
   const savedQueriesRef = useRef<SavedQuery[]>(savedQueries);
   savedQueriesRef.current = savedQueries;
+
+  // Mirror savedDatasets too, so a failed dataset removal can name the dataset
+  // (which the caller identifies only by id) in its error message.
+  const savedDatasetsRef = useRef<SavedDataset[]>(savedDatasets);
+  savedDatasetsRef.current = savedDatasets;
 
   const mockUserDataRef = useRef<{ profile: UserProfile }>({
     // Clone the arrays so the mock API's push/filter operations don't mutate
@@ -280,7 +290,8 @@ function useUserDataState() {
 
   const getProfile = useCallback(async () => {
     const result = await callUserDataApi('GET', '/user/data');
-    if (result && 'body' in result && result.ok && result.body) {
+    if (result && 'body' in result && result.ok) {
+      setError(null);
       const profile = result.body as Partial<UserProfile>;
       const keys: (keyof UserProfile)[] = [
         'ai_toggle_preference',
@@ -305,6 +316,14 @@ function useUserDataState() {
       if (Array.isArray(profile.favorite_datasets)) {
         setSavedDatasets(profile.favorite_datasets);
       }
+    } else if (result && 'status' in result && result.status !== 401) {
+      // A 401 just means the user isn't logged in (expected on public pages) —
+      // stay silent. Any other HTTP error is a real failure to load saved data.
+      // Network errors (no `status`) are left silent too, matching how auth
+      // treats them (e.g. expected CORS failures in dev).
+      setError(
+        'Unable to load your saved queries and resources. Please refresh to try again.',
+      );
     }
     return result;
   }, [callUserDataApi]);
@@ -341,7 +360,11 @@ function useUserDataState() {
           setSavedQueries(parseSavedQueries(body.favorite_searches));
         }
       } else {
-        setError('Unable to save this query. Please try again.');
+        setError(
+          `Couldn't save the search "${truncateLabel(
+            search.query,
+          )}". Please try again.`,
+        );
       }
       return result;
     },
@@ -375,7 +398,11 @@ function useUserDataState() {
           setSavedQueries(parseSavedQueries(body.favorite_searches));
         }
       } else {
-        setError('Unable to remove this saved query. Please try again.');
+        setError(
+          `Couldn't remove the saved search "${truncateLabel(
+            search.query,
+          )}". Please try again.`,
+        );
       }
       return result;
     },
@@ -396,7 +423,9 @@ function useUserDataState() {
           setSavedDatasets(body.favorite_datasets);
         }
       } else {
-        setError('Unable to save this resource. Please try again.');
+        setError(
+          `Couldn't save "${truncateLabel(dataset.name)}". Please try again.`,
+        );
       }
       return result;
     },
@@ -419,7 +448,14 @@ function useUserDataState() {
           setSavedDatasets(body.favorite_datasets);
         }
       } else {
-        setError('Unable to remove this saved resource. Please try again.');
+        const name = savedDatasetsRef.current.find(
+          dataset => dataset.dataset_id === datasetId,
+        )?.name;
+        setError(
+          `Couldn't remove ${
+            name ? `"${truncateLabel(name)}"` : 'this saved resource'
+          }. Please try again.`,
+        );
       }
       return result;
     },

--- a/src/hooks/useUserData/mocks/saved_queries.ts
+++ b/src/hooks/useUserData/mocks/saved_queries.ts
@@ -13,6 +13,7 @@ export const MOCK_SAVED_QUERIES: SavedQuery[] = [
       '-_exists_': ['date'],
     },
     saved_at: '2026-06-30T19:59:21.733Z',
+    total: 12085524,
   },
   {
     total: 1234,

--- a/src/hooks/useUserData/mocks/saved_queries.ts
+++ b/src/hooks/useUserData/mocks/saved_queries.ts
@@ -6,36 +6,45 @@ import { SavedQuery } from '../types';
  */
 export const MOCK_SAVED_QUERIES: SavedQuery[] = [
   {
+    query: '__all__',
+    name: 'All Results',
+    filters: {
+      date: ['2000-01-01', '2026-12-31'],
+      '-_exists_': ['date'],
+    },
+    saved_at: '2026-06-30T19:59:21.733Z',
+  },
+  {
     total: 1234,
-    name: `Search: "SARS-CoV-2" OR "Covid-19" OR "Wuhan coronavirus" OR "Wuhan pneumonia" OR "2019-nCoV" OR "HCoV-19"`,
+    name: `"SARS-CoV-2" OR "Covid-19" OR "Wuhan coronavirus" OR "Wuhan pneumonia" OR "2019-nCoV" OR "HCoV-19"`,
     query: `"SARS-CoV-2" OR "Covid-19" OR "Wuhan coronavirus" OR "Wuhan pneumonia" OR "2019-nCoV" OR "HCoV-19"`,
     filters: {},
     saved_at: '2026-06-03T17:04:55+00:00',
   },
   {
     total: 5678,
-    name: `Search: "Asthma"`,
+    name: `"Asthma"`,
     query: `"Asthma"`,
     filters: {},
     saved_at: '2026-06-09T16:21:22+00:00',
   },
   {
     total: 91011,
-    name: `Search: "HIV" OR "AIDS"`,
+    name: `"HIV" OR "AIDS"`,
     query: `"HIV" OR "AIDS"`,
     filters: {},
     saved_at: '2026-06-09T16:21:32+00:00',
   },
   {
     total: 1213,
-    name: `Search: "Influenza" OR "Flu"`,
+    name: `"Influenza" OR "Flu"`,
     query: `"Influenza" OR "Flu"`,
     filters: {},
     saved_at: '2026-06-09T16:21:37+00:00',
   },
   {
     total: 1415,
-    name: `Search: "Malaria" OR "Plasmodium falciparum" OR "Plasmodium malariae" OR "Plasmodium ovale curtisi" OR "Plasmodium ovale wallikeri" OR "Plasmodium vivax" OR "Plasmodium knowlesi"`,
+    name: `"Malaria" OR "Plasmodium falciparum" OR "Plasmodium malariae" OR "Plasmodium ovale curtisi" OR "Plasmodium ovale wallikeri" OR "Plasmodium vivax" OR "Plasmodium knowlesi"`,
     query: `"Malaria" OR "Plasmodium falciparum" OR "Plasmodium malariae" OR "Plasmodium ovale curtisi" OR "Plasmodium ovale wallikeri" OR "Plasmodium vivax" OR "Plasmodium knowlesi"`,
     filters: {
       date: [
@@ -51,7 +60,7 @@ export const MOCK_SAVED_QUERIES: SavedQuery[] = [
   },
   {
     total: 1617,
-    name: `Search: "Tuberculosis" OR "Mycobacterium bovis" OR "Mycobacterium africanum" OR "Mycobacterium canetti" OR "Mycobacterium microti" OR "Phthisis"`,
+    name: `"Tuberculosis" OR "Mycobacterium bovis" OR "Mycobacterium africanum" OR "Mycobacterium canetti" OR "Mycobacterium microti" OR "Phthisis"`,
     query: `"Tuberculosis" OR "Mycobacterium bovis" OR "Mycobacterium africanum" OR "Mycobacterium canetti" OR "Mycobacterium microti" OR "Phthisis"`,
     filters: {},
     saved_at: '2026-06-09T16:21:45+00:00',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { GoogleTagManager } from '@next/third-parties/google';
 import { fonts } from 'lib/fonts';
 import { ChakraProvider } from '@chakra-ui/react';
 import { AuthProvider } from 'src/hooks/useAuth';
+import { UserDataProvider } from 'src/hooks/useUserData';
 
 // Creates an instance of react-query for the app.
 const queryClient = new QueryClient();
@@ -35,7 +36,9 @@ function App({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <ChakraProvider theme={theme}>
           <AuthProvider>
-            <Component {...pageProps} />
+            <UserDataProvider>
+              <Component {...pageProps} />
+            </UserDataProvider>
           </AuthProvider>
         </ChakraProvider>
       </QueryClientProvider>

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -19,6 +19,7 @@ import navigationData from 'src/components/resource-sections/resource-sections.j
 import { Route, showSection } from 'src/components/resource-sections/helpers';
 import { getQueryStatusError } from 'src/components/error/utils';
 import { Sidebar } from 'src/components/resource-sections/components/sidebar';
+import { SavedDataErrorToast } from 'src/views/saved/components/saved-data-error-toast';
 import SITE_CONFIG from 'configs/site.config.json';
 import { SiteConfig } from 'src/components/page-container/types';
 import { SHOULD_HIDE_SAMPLES } from 'src/utils/feature-flags';
@@ -147,6 +148,7 @@ const ResourcePage: NextPage = () => {
             flex={1}
             w='100%'
           >
+            <SavedDataErrorToast />
             {error ? (
               // [ERROR STATE]: API response error
               <Error>

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -81,7 +81,9 @@ const SavedPage = () => {
         description='A saved collection of frequently used queries.'
         columns={SAVED_QUERY_COLUMNS}
         data={savedQueries}
-        getRowId={(item, idx) => item.query || `__no-id-${idx}`}
+        getRowId={(item, idx) =>
+          item.query + JSON.stringify(item.filters) || `__no-id-${idx}`
+        }
         unit={{ singular: 'item', plural: 'items' }}
         searchPlaceholder='Search saved queries'
         searchAriaLabel='Search saved queries'

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -13,6 +13,7 @@ import {
   SAVED_RESOURCE_COLUMNS,
 } from 'src/views/saved/table-config';
 import { SavedTableSection } from 'src/views/saved/components/saved-table-section';
+import { SavedDataErrorBanner } from 'src/views/saved/components/saved-data-error-banner';
 import { useUserData } from 'src/hooks/useUserData';
 import { useBatchResourcesData } from 'src/views/saved/hooks/useBatchResourcesData';
 import { SavedResourceItem } from 'src/views/saved/types';
@@ -98,6 +99,7 @@ const SavedPage = () => {
             </Text>
           </Box>
         )}
+        <SavedDataErrorBanner />
       </Flex>
       <Divider />
       <SavedTableSection

--- a/src/pages/saved.tsx
+++ b/src/pages/saved.tsx
@@ -2,7 +2,7 @@
  * User Favorites Page - Protected route requiring authentication
  */
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Heading, Text, Flex, Divider } from '@chakra-ui/react';
 import { useAuth } from 'src/hooks/useAuth';
 import { withAuth } from 'src/components/auth/withAuth';
@@ -31,19 +31,43 @@ const SavedPage = () => {
   const { user } = useAuth();
   const { savedDatasets, savedQueries, isDevMode } = useUserData();
 
+  // Snapshot the saved items once, the first time they load, and render the
+  // tables from that snapshot rather than from the live (shrinking) lists. This
+  // keeps an un-bookmarked row visible — its bookmark icon flips to empty but the
+  // row stays so the user can re-bookmark it — and rows only reconcile on refresh.
+  // The live lists still drive each row's favorited state and the delete itself.
+  const [displayQueries, setDisplayQueries] = useState<typeof savedQueries>([]);
+  const [displayDatasets, setDisplayDatasets] = useState<typeof savedDatasets>(
+    [],
+  );
+  const capturedQueries = useRef(false);
+  const capturedDatasets = useRef(false);
+  useEffect(() => {
+    if (!capturedQueries.current && savedQueries.length > 0) {
+      capturedQueries.current = true;
+      setDisplayQueries(savedQueries);
+    }
+  }, [savedQueries]);
+  useEffect(() => {
+    if (!capturedDatasets.current && savedDatasets.length > 0) {
+      capturedDatasets.current = true;
+      setDisplayDatasets(savedDatasets);
+    }
+  }, [savedDatasets]);
+
   // Hydrate each saved resource with type / source / dateModified fetched by id.
   const datasetIds = useMemo(
-    () => savedDatasets.map(dataset => dataset.dataset_id),
-    [savedDatasets],
+    () => displayDatasets.map(dataset => dataset.dataset_id),
+    [displayDatasets],
   );
   const { data: resourceData } = useBatchResourcesData(datasetIds);
   const enrichedDatasets = useMemo<SavedResourceItem[]>(
     () =>
-      savedDatasets.map(dataset => ({
+      displayDatasets.map(dataset => ({
         ...dataset,
         ...resourceData?.[dataset.dataset_id],
       })),
-    [savedDatasets, resourceData],
+    [displayDatasets, resourceData],
   );
 
   if (!user || !ENABLE_AUTH) return null;
@@ -80,7 +104,7 @@ const SavedPage = () => {
         title='Saved Queries'
         description='A saved collection of frequently used queries.'
         columns={SAVED_QUERY_COLUMNS}
-        data={savedQueries}
+        data={displayQueries}
         getRowId={(item, idx) =>
           item.query + JSON.stringify(item.filters) || `__no-id-${idx}`
         }

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -16,6 +16,7 @@ import {
   defaultSelectedFilters,
 } from 'src/views/search/config/defaultQuery';
 import { SearchResultsHeader } from 'src/views/search/components/search-results-header';
+import { SavedDataErrorToast } from 'src/views/saved/components/saved-data-error-toast';
 import { PaginationProvider } from 'src/views/search/context/pagination-context';
 import { SearchResultsController } from 'src/views/search/components/search-results-tabs-controller';
 import { fetchSearchResults } from 'src/utils/api';
@@ -224,6 +225,7 @@ const Search: NextPage<{
                   borderColor='gray.100'
                   spacing={2}
                 >
+                  <SavedDataErrorToast />
                   <Flex flex={1} flexDirection='column' width='100%'>
                     <Flex flex={1} justifyContent='flex-end'>
                       <OntologyBrowserPopup

--- a/src/views/saved/components/saved-data-error-banner.tsx
+++ b/src/views/saved/components/saved-data-error-banner.tsx
@@ -17,6 +17,7 @@ export const SavedDataErrorBanner = () => {
   return (
     <Flex
       role='alert'
+      width='100%'
       px={2}
       py={2}
       borderLeft='0.5rem solid'

--- a/src/views/saved/components/saved-data-error-banner.tsx
+++ b/src/views/saved/components/saved-data-error-banner.tsx
@@ -1,0 +1,41 @@
+import { CloseButton, Flex, HStack, Icon, Text } from '@chakra-ui/react';
+import { FaCircleXmark } from 'react-icons/fa6';
+import { useUserData } from 'src/hooks/useUserData';
+
+/**
+ * Surfaces the last failed saved-items action (save/remove of a query or
+ * resource) as a dismissible banner, so a failed request — e.g. the favorites
+ * API rejecting a delete — isn't silent. Reads shared state from `useUserData`,
+ * so it reflects failures from any consumer and clears on the next success.
+ * Mirrors the `LoginErrorBanner` styling for consistency.
+ */
+export const SavedDataErrorBanner = () => {
+  const { error, clearError } = useUserData();
+
+  if (!error) return null;
+
+  return (
+    <Flex
+      role='alert'
+      px={2}
+      py={2}
+      borderLeft='0.5rem solid'
+      borderColor='status.error'
+      bg='status.error_lt'
+    >
+      <HStack spacing={4} flex={1} justifyContent='space-between'>
+        <HStack flex={1} spacing={{ base: 2, sm: 4 }} alignItems='flex-start'>
+          <Icon as={FaCircleXmark} boxSize={6} fill='status.error' />
+          <Text fontSize='md' fontWeight='medium' lineHeight='short'>
+            {error}
+          </Text>
+        </HStack>
+        <CloseButton
+          aria-label='Dismiss error'
+          size='sm'
+          onClick={clearError}
+        />
+      </HStack>
+    </Flex>
+  );
+};

--- a/src/views/saved/components/saved-data-error-toast.test.tsx
+++ b/src/views/saved/components/saved-data-error-toast.test.tsx
@@ -1,0 +1,69 @@
+import { render } from '@testing-library/react';
+import { SavedDataErrorToast } from './saved-data-error-toast';
+import { useUserData } from 'src/hooks/useUserData';
+
+// The component only uses `useToast` from Chakra and renders null, so a minimal
+// module mock keeps the test light.
+const mockToast = Object.assign(jest.fn(), {
+  isActive: jest.fn(() => false),
+});
+jest.mock('@chakra-ui/react', () => ({
+  useToast: () => mockToast,
+}));
+
+jest.mock('src/hooks/useUserData', () => ({
+  useUserData: jest.fn(),
+}));
+
+const mockUseUserData = useUserData as jest.Mock;
+
+describe('SavedDataErrorToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockToast.isActive.mockReturnValue(false);
+  });
+
+  it('fires an error toast and clears the error when one is present', () => {
+    const clearError = jest.fn();
+    const message = `Couldn't save "Malaria Atlas". Please try again.`;
+    mockUseUserData.mockReturnValue({ error: message, clearError });
+
+    render(<SavedDataErrorToast />);
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: message,
+        title: message,
+        status: 'error',
+        isClosable: true,
+      }),
+    );
+    expect(clearError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toast a duplicate that is already active', () => {
+    mockToast.isActive.mockReturnValue(true);
+    const clearError = jest.fn();
+    mockUseUserData.mockReturnValue({
+      error: 'Something failed. Please try again.',
+      clearError,
+    });
+
+    render(<SavedDataErrorToast />);
+
+    expect(mockToast).not.toHaveBeenCalled();
+    // Still consumes the error so it doesn't linger.
+    expect(clearError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when there is no error', () => {
+    const clearError = jest.fn();
+    mockUseUserData.mockReturnValue({ error: null, clearError });
+
+    render(<SavedDataErrorToast />);
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(clearError).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/saved/components/saved-data-error-toast.tsx
+++ b/src/views/saved/components/saved-data-error-toast.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useUserData } from 'src/hooks/useUserData';
+
+/**
+ * Surfaces the shared saved-items error (the same `error` the banner reads) as a
+ * Chakra toast, for pages where an inline banner would be intrusive — e.g. the
+ * search and resource pages, where saving happens via a small bookmark button.
+ *
+ * It shows the message once, then clears the shared error so it can't re-fire or
+ * leak onto another page (e.g. the /saved banner). The `id` keyed on the message
+ * dedupes repeats (and guards against StrictMode's double-invoked effects).
+ * Renders nothing.
+ */
+export const SavedDataErrorToast = () => {
+  const toast = useToast();
+  const { error, clearError } = useUserData();
+
+  useEffect(() => {
+    if (!error) return;
+    if (!toast.isActive(error)) {
+      toast({
+        id: error,
+        title: error,
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+    clearError();
+  }, [error, toast, clearError]);
+
+  return null;
+};

--- a/src/views/saved/components/saved-table-section.tsx
+++ b/src/views/saved/components/saved-table-section.tsx
@@ -118,7 +118,7 @@ export function SavedTableSection<TItem>({
   const getTableRowProps = useCallback(
     (_: any, idx: number) => ({
       bg: idx % 2 === 0 ? 'white' : '#fafbfd',
-      _hover: { bg: 'secondary.50' },
+      // _hover: { bg: 'secondary.50' },
     }),
     [],
   );

--- a/src/views/saved/table-config.tsx
+++ b/src/views/saved/table-config.tsx
@@ -12,6 +12,7 @@ import { defaultSearchValue } from '../repository-matcher/hooks/useRepositoryMat
 import { BookmarkIconButton } from 'src/components/bookmark-buttons/icon-button';
 import { SavedDataset, SavedQuery } from 'src/hooks/useUserData/types';
 import { useUserData } from 'src/hooks/useUserData';
+import { findSavedQueryIndex } from 'src/hooks/useUserData/helpers';
 import {
   FILTER_CONFIGS,
   queryFilterObject2String,
@@ -63,17 +64,16 @@ const SavedQueryNameCell = ({
   isLoading?: boolean;
 }) => {
   const { savedQueries, addSavedQuery, removeSavedQuery } = useUserData();
-  const favoriteIndex = savedQueries.findIndex(
-    search => search.query === value.query,
-  );
-  const isFavorited = favoriteIndex !== -1;
+  // Match on query AND filters: the same query string can be saved more than
+  // once with different filters, and each must be favorited/removed on its own.
+  const isFavorited = findSavedQueryIndex(savedQueries, value) !== -1;
   return (
     <HStack alignItems='flex-start'>
       <BookmarkIconButton
         isFavorited={isFavorited}
         aria-label={isFavorited ? 'Remove saved query' : 'Save query'}
         onClick={() =>
-          isFavorited ? removeSavedQuery(favoriteIndex) : addSavedQuery(value)
+          isFavorited ? removeSavedQuery(value) : addSavedQuery(value)
         }
         alignItems='flex-start'
         mt={1}

--- a/src/views/saved/table-config.tsx
+++ b/src/views/saved/table-config.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HStack, Text, VStack } from '@chakra-ui/react';
+import { Flex, HStack, Text, VStack } from '@chakra-ui/react';
 import { getMetadataName } from 'src/components/metadata';
 import {
   TagCell,
@@ -40,10 +40,8 @@ const SavedResourceNameCell = ({
             ? removeSavedDataset(value.dataset_id)
             : addSavedDataset(value)
         }
-        alignItems='flex-start'
-        mt={1}
       />
-      <VStack alignItems='flex-start' spacing={1} fontSize='xs'>
+      <VStack alignItems='flex-start' spacing={1} fontSize='xs' pt={1}>
         <TextCellWithLink
           label={value?.name || ''}
           url={value?.url}
@@ -75,15 +73,15 @@ const SavedQueryNameCell = ({
         onClick={() =>
           isFavorited ? removeSavedQuery(value) : addSavedQuery(value)
         }
-        alignItems='flex-start'
-        mt={1}
       />
-      <TextCellWithLink
-        label={value?.name || ''}
-        url={value?.url}
-        isLoading={isLoading}
-        isExternal={false}
-      />
+      <Flex pt={1}>
+        <TextCellWithLink
+          label={value?.name || ''}
+          url={value?.url}
+          isLoading={isLoading}
+          isExternal={false}
+        />
+      </Flex>
     </HStack>
   );
 };

--- a/src/views/saved/table-config.tsx
+++ b/src/views/saved/table-config.tsx
@@ -79,7 +79,7 @@ const SavedQueryNameCell = ({
         mt={1}
       />
       <TextCellWithLink
-        label={value?.query || ''}
+        label={value?.name || ''}
         url={value?.url}
         isLoading={isLoading}
         isExternal={false}

--- a/src/views/search/components/filters/__tests__/components/tag/utils.test.ts
+++ b/src/views/search/components/filters/__tests__/components/tag/utils.test.ts
@@ -68,6 +68,32 @@ describe('tag/utils', () => {
     ).toEqual([]);
   });
 
+  it('creates a tag when filter values are unexpectedly a string', () => {
+    expect(
+      generateTags({ conditionsOfAccess: 'restricted' } as any, configMap),
+    ).toEqual([
+      {
+        key: 'conditionsOfAccess-0',
+        filterKey: 'conditionsOfAccess',
+        name: 'Conditions',
+        value: 'restricted',
+        displayValue: 'coa-restricted',
+      },
+    ]);
+  });
+
+  it('creates a date tag when date values are unexpectedly a string', () => {
+    expect(generateTags({ date: '2020-01-01' } as any, configMap)).toEqual([
+      {
+        key: 'date-0',
+        filterKey: 'date',
+        name: 'Date',
+        value: '2020-01-01',
+        displayValue: '2020-01-01',
+      },
+    ]);
+  });
+
   it('creates transformed, display-name, and exists tags', () => {
     const tags = generateTags(
       {

--- a/src/views/search/components/filters/components/tag/utils.ts
+++ b/src/views/search/components/filters/components/tag/utils.ts
@@ -28,8 +28,24 @@ const isStringValue = (value: unknown): value is string =>
 const isObjectValue = (value: unknown): value is Record<string, unknown> =>
   isPlainObject(value);
 
+const coerceTagValues = (values: unknown): SelectedFilterValueType[] => {
+  if (Array.isArray(values)) {
+    return values;
+  }
+
+  if (typeof values === 'string') {
+    return values ? [values] : [];
+  }
+
+  if (isObjectValue(values)) {
+    return [values as { [key: string]: string[] }];
+  }
+
+  return [];
+};
+
 const isDateRangeValues = (
-  values: (string | SelectedFilterValueType)[],
+  values: SelectedFilterValueType[],
 ): values is [string, string] =>
   values.length === 2 && isStringValue(values[0]) && isStringValue(values[1]);
 
@@ -62,7 +78,7 @@ const applyConfigTransform = (value: string, config?: FilterConfig): string => {
 const getDisplayValue = (
   key: string,
   value: string | SelectedFilterValueType,
-  values: (string | SelectedFilterValueType)[],
+  values: SelectedFilterValueType[],
   index: number,
   config?: FilterConfig,
 ): string => {
@@ -97,7 +113,7 @@ const getDisplayValue = (
 };
 
 // Checks if a filter represents a date exists/not exists query
-const stripDateExistsQuery = (values: (string | SelectedFilterValueType)[]) => {
+const stripDateExistsQuery = (values: SelectedFilterValueType[]) => {
   return values.filter(
     value =>
       !isObjectValue(value) &&
@@ -123,15 +139,20 @@ const createDateRangeTag = (
 const createValueTags = (
   key: string,
   name: string,
-  values: (string | SelectedFilterValueType)[],
+  values: unknown,
   config?: FilterConfig,
 ): TagInfo[] => {
-  return values
+  const tagValues = coerceTagValues(values);
+  if (tagValues.length === 0) {
+    return [];
+  }
+
+  return tagValues
     .map((rawValue, index): TagInfo | null => {
       const displayValue = getDisplayValue(
         key,
         rawValue,
-        values,
+        tagValues,
         index,
         config,
       );
@@ -166,10 +187,15 @@ export const generateTags = (
   return Object.entries(selectedFilters).flatMap(([key, values]) => {
     const config = configMap[key];
     const name = generateTagName(key, config);
+    const tagValues = coerceTagValues(values);
+
+    if (tagValues.length === 0) {
+      return [];
+    }
 
     // Handle date ranges as a single tag
     if (key === DATE_FILTER_KEY) {
-      const cleanedDateValues = stripDateExistsQuery(values);
+      const cleanedDateValues = stripDateExistsQuery(tagValues);
 
       if (cleanedDateValues?.length === 0) {
         return [];

--- a/src/views/search/components/search-results-header/index.tsx
+++ b/src/views/search/components/search-results-header/index.tsx
@@ -11,32 +11,9 @@ import { Link } from 'src/components/link';
 import { AI_ASSISTED_SEARCH_KC_LINK } from 'src/components/page-container/components/search/components/ai-toggle';
 import { useAuth } from 'src/hooks/useAuth';
 import { useUserData } from 'src/hooks/useUserData';
+import { findSavedQueryIndex } from 'src/hooks/useUserData/helpers';
 import { ENABLE_AUTH } from 'src/utils/feature-flags';
 import { SelectedFilterType } from '../filters';
-
-/**
- * Stringify a value with object keys sorted recursively, so that two
- * structurally-equal filter objects compare equal regardless of key order.
- * Array order is preserved (it is meaningful for filters such as
- * `date: [start, end, ...]`).
- */
-const stableStringify = (value: unknown): string => {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`;
-  }
-  if (value && typeof value === 'object') {
-    const entries = Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map(
-        key =>
-          `${JSON.stringify(key)}:${stableStringify(
-            (value as Record<string, unknown>)[key],
-          )}`,
-      );
-    return `{${entries.join(',')}}`;
-  }
-  return JSON.stringify(value) ?? 'null';
-};
 
 export const SearchResultsHeading = ({ children, ...props }: TextProps) => {
   return (
@@ -81,12 +58,11 @@ export const SearchResultsHeader = ({
 
   const { savedQueries, addSavedQuery, removeSavedQuery } = useUserData();
 
-  const favoriteIndex = savedQueries.findIndex(
-    search =>
-      search.query === querystring &&
-      stableStringify(search.filters) === stableStringify(selectedFilters),
-  );
-  const isFavorited = favoriteIndex !== -1;
+  const isFavorited =
+    findSavedQueryIndex(savedQueries, {
+      query: querystring,
+      filters: selectedFilters,
+    }) !== -1;
   return (
     <VStack alignItems='flex-start' spacing={1} fontSize='sm' flex={1}>
       {showAIBanner && (
@@ -133,7 +109,10 @@ export const SearchResultsHeader = ({
                   return;
                 }
                 return isFavorited
-                  ? removeSavedQuery(favoriteIndex)
+                  ? removeSavedQuery({
+                      query: querystring,
+                      filters: selectedFilters,
+                    })
                   : addSavedQuery({
                       query: querystring,
                       name: `Search: ${querystring}`,

--- a/src/views/search/components/search-results-header/index.tsx
+++ b/src/views/search/components/search-results-header/index.tsx
@@ -2,6 +2,7 @@ import {
   Flex,
   FlexProps,
   HStack,
+  Stack,
   Text,
   TextProps,
   VStack,
@@ -83,17 +84,23 @@ export const SearchResultsHeader = ({
         </AIBanner>
       )}
       {/* Heading: Showing results for... */}
-      <SearchResultsHeading as='h1' fontSize='inherit'>
-        {querystring === '__all__'
-          ? 'Showing all results'
-          : 'Showing results for: '}
-      </SearchResultsHeading>
-      {/* Query string */}
-      {querystring !== '__all__' && (
+      <Stack
+        // Use row layout for "All Results" and column layout for other queries
+        flexDirection={querystring === '__all__' ? 'row' : 'column'}
+        spacing={1}
+      >
+        <SearchResultsHeading as='h1' fontSize='inherit' whiteSpace='nowrap'>
+          {querystring === '__all__'
+            ? 'Showing all results'
+            : 'Showing results for: '}
+        </SearchResultsHeading>
+        {/* Query string */}
         <HStack spacing={1} width='100%' alignItems='flex-start'>
-          <Text color='text.heading' fontSize='inherit' fontWeight='medium'>
-            {querystring.replaceAll('\\', '')}
-          </Text>
+          {querystring !== '__all__' && (
+            <Text color='text.heading' fontSize='inherit' fontWeight='medium'>
+              {querystring.replaceAll('\\', '')}
+            </Text>
+          )}
 
           {ENABLE_AUTH && (
             <BookmarkIconButton
@@ -115,14 +122,16 @@ export const SearchResultsHeader = ({
                     })
                   : addSavedQuery({
                       query: querystring,
-                      name: `Search: ${querystring}`,
+                      name: `${
+                        querystring === '__all__' ? 'All results' : querystring
+                      }`,
                       filters: selectedFilters,
                     });
               }}
             />
           )}
         </HStack>
-      )}
+      </Stack>
     </VStack>
   );
 };


### PR DESCRIPTION
This pull request significantly improves the reliability and user experience of saving and removing user favorites (saved queries and datasets) in the application. The main focus is on providing clear error messages and increasing test coverage for these scenarios. The changes also add utilities for comparing queries by value, not just by index, and improve the feedback given to users when an operation fails.

**Key improvements and fixes:**

### Robustness and Correctness of Saved Query Deletion

* Introduced `stableStringify` and `findSavedQueryIndex` utilities to compare saved queries by value (query string + filters), ensuring that deletes always target the correct item even if the list changes between operations. This prevents "Index out of range" errors when deleting multiple saved queries in a row. 
* Updated `removeSavedQuery` to resolve the index from the latest state at call time, rather than relying on potentially stale indices.

### Improved Error Handling and User Feedback

* Added detailed error state management: errors from failed mutations are surfaced to the UI as banners, with clear, concise messages that include the relevant query or dataset name (truncated for length). Errors are cleared on subsequent successes or manual dismissal. 
* Enhanced error handling for loading user data: distinguishes between expected (401/unauthorized) and unexpected errors, surfacing only real failures to the user.

### Test Coverage

* Added comprehensive regression and unit tests to ensure correct behavior when deleting saved queries, including edge cases (e.g., deleting multiple items sequentially, handling queries with identical strings but different filters, error propagation, and silent handling of 401s).

### Code Quality and Developer Experience

* Refactored the user data hook to encapsulate state and error management, and to export a consistent API for use throughout the app. 
* Added a utility to truncate long labels in error messages to keep banners readable.

### Minor UI Enhancement

* Set the color scheme of the `BookmarkIconButton` to blue for visual consistency.
* Added bookmark to general "__all__" queries