### PR TITLE
fix(search-results-page): prevent compact card from resizing when changing tabs

### DIFF
--- a/src/components/carousel/hooks/useCarouselState.ts
+++ b/src/components/carousel/hooks/useCarouselState.ts
@@ -45,6 +45,12 @@ export const useCarouselState = ({
 
   // Update itemWidth and constraint based on screen size
   useEffect(() => {
+    // While the carousel container is hidden, the ResizeObserver reports
+    // width 0. In that case, the last correct itemWidth/constraint
+    // and derived positions persist to prevent cards from flashing to a
+    // wrong width when the carousel becomes visible again.
+    if (width <= 0) return;
+
     if (isBetweenBaseAndMd) {
       setItemWidth(width - gap);
       setConstraint(1);


### PR DESCRIPTION
# Summary

This PR improves the user experience by maintaining consistent **resource catalog** and **disease overview** card dimensions when portal visitors switch tabs on the **Search Results** page.

Related issue: https://github.com/NIAID-Data-Ecosystem/nde-portal/issues/326