### PR TITLE
feat: use sticky header

### DIFF
--- a/src/components/resource-sections/components/samples/components/SampleTable/index.tsx
+++ b/src/components/resource-sections/components/samples/components/SampleTable/index.tsx
@@ -38,6 +38,7 @@ export const SampleTable = ({
       <Table
         ariaLabel={label}
         caption={caption}
+        stickyHeader
         tableContainerProps={{
           overflowY: 'auto',
           maxHeight: '400px',


### PR DESCRIPTION
# Summary

This PR implements a sticky header for the samples table on the **Resource Page**, improving the user experience by keeping the column headers visible while visitors scroll through the table.