### PR TITLE
feat(search): allow name column to be hidden or moved around

### DIFF
--- a/src/views/search/components/results-list/components/results-table/constants.ts
+++ b/src/views/search/components/results-list/components/results-table/constants.ts
@@ -7,6 +7,6 @@
  * and its CustomizeColumnsPopover wrapper.
  */
 
-export const SAMPLE_REQUIRED_COLUMN_IDS = ['identifier', 'name'] as const;
+export const SAMPLE_REQUIRED_COLUMN_IDS = ['identifier'] as const;
 
 export const DATA_COLLECTION_REQUIRED_COLUMN_IDS = ['name', 'source'] as const;


### PR DESCRIPTION
# Summary

This PR allows the **Name** column in the sample table on the **Search Results** page to be hidden or reordered.