### PR TITLE
feat: add Microsoft and Google OAuth providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_ENV           = The environment of the app. Ex: production, stag
 NEXT_PUBLIC_GOOGLE_ANALYTICS  = Google analytics key to track user activity. (optional)
 NEXT_PUBLIC_API_URL           = NDE API url. Ex: https://api.data.niaid.nih.gov/v1 or https://api-staging.data.niaid.nih.gov/v1
 NEXT_PUBLIC_STRAPI_API_URL    = API URL to access Strapi cms content.
-NEXT_PUBLIC_AUTH_PROVIDERS    = Comma-separated list of auth providers to enable. Ex: "github,orcid"
+NEXT_PUBLIC_AUTH_PROVIDERS    = Comma-separated list of auth providers to enable. Supported: github, orcid, google, microsoft. Ex: "github,orcid" (google and microsoft are UI-ready but not yet wired up on the API side)
 
 # Dev-only mock auth mode (bypasses /user_info CORS dependency)
 NEXT_PUBLIC_MOCK_AUTH_USER_INFO = Set to "true" to enable mock auth mode in development. In this mode, the app will use the following environment variables to mock an authenticated user.

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_ENV           = The environment of the app. Ex: production, stag
 NEXT_PUBLIC_GOOGLE_ANALYTICS  = Google analytics key to track user activity. (optional)
 NEXT_PUBLIC_API_URL           = NDE API url. Ex: https://api.data.niaid.nih.gov/v1 or https://api-staging.data.niaid.nih.gov/v1
 NEXT_PUBLIC_STRAPI_API_URL    = API URL to access Strapi cms content.
-NEXT_PUBLIC_AUTH_PROVIDERS    = Comma-separated list of auth providers to enable. Supported: github, orcid, google, microsoft. Ex: "github,orcid" (google and microsoft are UI-ready but not yet wired up on the API side)
+NEXT_PUBLIC_AUTH_PROVIDERS    = Comma-separated list of auth providers to enable. Supported: github, orcid, google, microsoft. Ex: "github,orcid" (google and microsoft are staging ready only)
 
 # Dev-only mock auth mode (bypasses /user_info CORS dependency)
 NEXT_PUBLIC_MOCK_AUTH_USER_INFO = Set to "true" to enable mock auth mode in development. In this mode, the app will use the following environment variables to mock an authenticated user.

--- a/.env.staging
+++ b/.env.staging
@@ -3,4 +3,4 @@ NEXT_PUBLIC_API_URL=https://api-staging.data.niaid.nih.gov/v1
 NEXT_PUBLIC_GOOGLE_ANALYTICS=GTM-K8WGDTD
 NEXT_PUBLIC_APP_ENV=staging
 NEXT_PUBLIC_STRAPI_API_URL=https://data-staging.niaid.nih.gov/strapi
-NEXT_PUBLIC_AUTH_PROVIDERS="GitHub,ORCID"
+NEXT_PUBLIC_AUTH_PROVIDERS="GitHub,ORCID,microsoft,google"

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -14,7 +14,13 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react';
-import { FaCheck, FaGithub, FaOrcid } from 'react-icons/fa6';
+import {
+  FaCheck,
+  FaGithub,
+  FaGoogle,
+  FaMicrosoft,
+  FaOrcid,
+} from 'react-icons/fa6';
 import { useRouter } from 'next/router';
 import { getPageSeoConfig, PageContainer } from 'src/components/page-container';
 import { useAuth } from 'src/hooks/useAuth';
@@ -36,6 +42,18 @@ const ProviderIcon = ({ providerId }: { providerId: string }) => {
   if (providerId.toLowerCase() === 'github') {
     return (
       <Icon as={FaGithub} color='#24292e ' boxSize={5} aria-hidden='true' />
+    );
+  }
+
+  if (providerId.toLowerCase() === 'google') {
+    return (
+      <Icon as={FaGoogle} color='#4285F4' boxSize={5} aria-hidden='true' />
+    );
+  }
+
+  if (providerId.toLowerCase() === 'microsoft') {
+    return (
+      <Icon as={FaMicrosoft} color='#00A4EF' boxSize={5} aria-hidden='true' />
     );
   }
 
@@ -78,7 +96,7 @@ function LoginPage() {
   return (
     <PageContainer meta={getPageSeoConfig('/login')} px={0} py={0}>
       <Flex
-        minH={{ base: 'auto', lg: 'calc(100vh - 180px)' }}
+        minH={{ base: 'auto', lg: '80vh' }}
         flexDirection={{ base: 'column', lg: 'row' }}
       >
         <Flex

--- a/src/utils/auth/config.test.ts
+++ b/src/utils/auth/config.test.ts
@@ -15,6 +15,8 @@ describe('auth config', () => {
   it('builds labels with overrides and title case fallback', () => {
     expect(getProviderLabel('github')).toBe('GitHub');
     expect(getProviderLabel('orcid')).toBe('ORCID');
+    expect(getProviderLabel('google')).toBe('Google');
+    expect(getProviderLabel('microsoft')).toBe('Microsoft');
     expect(getProviderLabel('nih-login_provider')).toBe('Nih Login Provider');
   });
 

--- a/src/utils/auth/types.ts
+++ b/src/utils/auth/types.ts
@@ -10,7 +10,7 @@ export interface AuthLoginProvider {
 
 export interface User {
   username: string;
-  oauth_provider: string; // "GitHub" or "ORCID"
+  oauth_provider: string; // e.g. "GitHub", "ORCID", "Google", "Microsoft"
   name: string;
   // Primary email address for the user, if available. This is an array to accommodate multiple emails from ORCID and github. Set by the backend API.
   email?: string;


### PR DESCRIPTION
[Addresses [Feedback/Guidance request]: Adding OAUTH sources](https://github.com/NIAID-Data-Ecosystem/niaid-feedback/issues/300)

This pull request updates authentication provider support by adding Google and Microsoft as new options in the UI, improving documentation, and updating tests and types to reflect these changes. While Google and Microsoft are now selectable in the UI, the backend integration for these providers is not yet complete.

**Authentication provider expansion:**

* Added Google and Microsoft as supported authentication providers in the UI, including their icons in the login page (`src/pages/login.tsx`). [[1]](diffhunk://#diff-cd54149b4c3f0a12502acd6d824b642db9085fd7c1a403bd829ce37439294a2eL17-R23) [[2]](diffhunk://#diff-cd54149b4c3f0a12502acd6d824b642db9085fd7c1a403bd829ce37439294a2eR48-R59)
* Updated `.env.example` and `.env.staging` to document and enable Google and Microsoft as available authentication providers, clarifying their current status. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL7-R7) [[2]](diffhunk://#diff-53003b50d89f576ea396020048779f70e1f21c14f36ac067c52c269e041c50d9L6-R6)

**Testing and type updates:**

* Extended `getProviderLabel` tests to include Google and Microsoft, ensuring correct label formatting (`src/utils/auth/config.test.ts`).
* Updated the `User` type to include Google and Microsoft as possible `oauth_provider` values (`src/utils/auth/types.ts`).

**UI adjustment:**

* Slightly changed the login page layout for better appearance (`src/pages/login.tsx`).