### PR TITLE
feat: update niaid funded list + sitemap generation

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -8,14 +8,22 @@ if (!process.env.BASE_URL) {
 }
 
 const datasetDir = path.join(__dirname, 'public/sitemaps/datasets');
+const DATASET_SITEMAP_INDEX = 'sitemap-index.xml';
 
 const getAdditionalSitemaps = () => {
   // Retrieve the list of additional sitemaps from the 'sitemaps' directory
   const files = fs.existsSync(datasetDir) ? fs.readdirSync(datasetDir) : [];
+  const xmlFiles = files.filter(file => file.endsWith('.xml'));
 
-  return files
-    .filter(file => file.endsWith('.xml'))
-    .map(file => `${process.env.BASE_URL}/sitemaps/datasets/${file}`);
+  // The sitemap index already points at every per-source sitemap, so list it
+  // alone rather than duplicating each of its entries in robots.txt.
+  const sitemaps = xmlFiles.includes(DATASET_SITEMAP_INDEX)
+    ? [DATASET_SITEMAP_INDEX]
+    : xmlFiles;
+
+  return sitemaps.map(
+    file => `${process.env.BASE_URL}/sitemaps/datasets/${file}`,
+  );
 };
 
 // Exclude paths that are not in production based on the site configuration.

--- a/scripts/generate-dataset-sitemaps.ts
+++ b/scripts/generate-dataset-sitemaps.ts
@@ -20,6 +20,11 @@ const OUTPUT_CSV_PATH = './public/sitemap-datasets.csv';
 const OUTPUT_SITEMAP_DIR = './public/sitemaps/datasets';
 const LOC_PATH = `${process.env.BASE_URL}/resources?id=`;
 
+// Public URL + filename for the sitemap index that lists every source sitemap.
+// This is the single file to submit to Google Search Console.
+const SITEMAP_URL_PATH = `${process.env.BASE_URL}/sitemaps/datasets`;
+const SITEMAP_INDEX_FILENAME = 'sitemap-index.xml';
+
 // Sources that should be omitted from the sitemap.
 const OMITTED_SOURCES = ['Data Discovery Engine'];
 
@@ -51,6 +56,21 @@ const buildSitemapXML = (urls: string[]): string => {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urlSet}
 </urlset>`;
+};
+
+// Build a sitemap index pointing at each of the per-source sitemap files.
+const buildSitemapIndexXML = (filenames: string[], lastmod: string): string => {
+  const sitemapSet = filenames
+    .map(
+      filename =>
+        `<sitemap><loc>${SITEMAP_URL_PATH}/${filename}</loc><lastmod>${lastmod}</lastmod></sitemap>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemapSet}
+</sitemapindex>`;
 };
 
 const toCsv = (groups: { source: string; results: FormattedResource[] }[]) => {
@@ -340,6 +360,9 @@ const writeSitemapContentPerSource = async (
     fs.mkdirSync(OUTPUT_SITEMAP_DIR, { recursive: true });
   }
 
+  // Filenames of the sitemaps successfully written, used to build the index.
+  const writtenSitemaps: string[] = [];
+
   for (const { source, results } of sources) {
     if (results.length === 0) {
       console.warn(`⚠️ No results found for source: ${source}`);
@@ -354,15 +377,17 @@ const writeSitemapContentPerSource = async (
 
     chunks.forEach((chunk, index) => {
       const label = String(index + 1).padStart(2, '0'); // 01, 02, 03
-      const sitemapPath =
+      const filename =
         chunks.length === 1
-          ? path.join(OUTPUT_SITEMAP_DIR, `${safeSourceName}.xml`)
-          : path.join(OUTPUT_SITEMAP_DIR, `${safeSourceName}-${label}.xml`);
+          ? `${safeSourceName}.xml`
+          : `${safeSourceName}-${label}.xml`;
+      const sitemapPath = path.join(OUTPUT_SITEMAP_DIR, filename);
 
       const sitemapContent = buildSitemapXML(chunk);
 
       try {
         fs.writeFileSync(sitemapPath, sitemapContent);
+        writtenSitemaps.push(filename);
         console.log(
           `✅ Sitemap written for ${source} [part ${index + 1}/${
             chunks.length
@@ -375,6 +400,29 @@ const writeSitemapContentPerSource = async (
         );
       }
     });
+  }
+
+  writeSitemapIndex(writtenSitemaps);
+};
+
+// Write a sitemap index listing every sitemap written in this run.
+const writeSitemapIndex = (filenames: string[]) => {
+  if (filenames.length === 0) {
+    console.warn('⚠️ No sitemaps were written — skipping sitemap index.');
+    return;
+  }
+
+  const indexPath = path.join(OUTPUT_SITEMAP_DIR, SITEMAP_INDEX_FILENAME);
+  const lastmod = new Date().toISOString();
+  const indexContent = buildSitemapIndexXML([...filenames].sort(), lastmod);
+
+  try {
+    fs.writeFileSync(indexPath, indexContent);
+    console.log(
+      `✅ Sitemap index written with ${filenames.length} sitemaps: ${indexPath}`,
+    );
+  } catch (error: any) {
+    console.error('❌ Error writing sitemap index:', error.message);
   }
 };
 

--- a/src/__tests__/mocks/data/index.ts
+++ b/src/__tests__/mocks/data/index.ts
@@ -237,14 +237,14 @@ export const mockRepositoriesMetadata = {
       version: '2024-04-22T22:23:30Z',
       upload_date: '2024-04-26T21:07:24.742000',
       sourceInfo: {
-        name: 'AccessClinicalData@NIAID',
+        name: 'accessclinicaldata@NIAID',
         abstract:
           'AccessClinicalData is a NIAID supported IID repository that includes clinical trials data.',
         description:
-          'AccessClinicalData@NIAID is a NIAID cloud-based, secure data platform that enables sharing of and access to reports and data sets from NIAID COVID-19 and other sponsored clinical trials for the basic and clinical research community.',
+          'accessclinicaldata@NIAID is a NIAID cloud-based, secure data platform that enables sharing of and access to reports and data sets from NIAID COVID-19 and other sponsored clinical trials for the basic and clinical research community.',
 
         url: 'https://accessclinicaldata.niaid.nih.gov/',
-        identifier: 'AccessClinicalData@NIAID',
+        identifier: 'accessclinicaldata@NIAID',
         conditionsOfAccess: 'Varied',
         genre: 'IID',
       },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,7 +5,7 @@ export const getFundedByNIAID = (name: string) => {
     return false;
   }
   const FUNDED_REPOS = [
-    'AccessClinicalData@NIAID',
+    'accessclinicaldata@NIAID',
     'ClinEpiDB',
     'ImmPort',
     'MicrobiomeDB',


### PR DESCRIPTION
This pull request introduces improvements to the dataset sitemap generation and indexing process, ensuring that only the sitemap index file is referenced for search engines and robots, and that all per-source sitemaps are properly included in the index. Additionally, it standardizes the casing for the "AccessClinicalData@NIAID" identifier and updates its references in test data and helper functions.

**Sitemap generation and indexing improvements:**

* Added logic to generate a `sitemap-index.xml` file that lists all per-source dataset sitemaps, and updated the code so that only this index is referenced in robots.txt and submitted to search engines. This avoids duplication and simplifies sitemap management. [[1]](diffhunk://#diff-8c4981164a106326e9988c8aa5267160938ea7950f33eac3d53ef206deb31e06R11-R26) [[2]](diffhunk://#diff-03629ea4deb228e1de3872aeaee03c121968b83c83260ce7627fea98294ce1e3R23-R27) [[3]](diffhunk://#diff-03629ea4deb228e1de3872aeaee03c121968b83c83260ce7627fea98294ce1e3R61-R75) [[4]](diffhunk://#diff-03629ea4deb228e1de3872aeaee03c121968b83c83260ce7627fea98294ce1e3R363-R365) [[5]](diffhunk://#diff-03629ea4deb228e1de3872aeaee03c121968b83c83260ce7627fea98294ce1e3L357-R390) [[6]](diffhunk://#diff-03629ea4deb228e1de3872aeaee03c121968b83c83260ce7627fea98294ce1e3R404-R426)

**Data and identifier consistency:**

* Standardized the casing for "AccessClinicalData@NIAID" to "accessclinicaldata@NIAID" in test data (`mockRepositoriesMetadata`) and updated the corresponding logic in the `getFundedByNIAID` helper function to match. [[1]](diffhunk://#diff-a62a34696acf4d0ffcbd17d4f534230c783dfaaa5a3f5c211cf7342d2f6504b8L240-R247) [[2]](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dL8-R8)